### PR TITLE
Prefer `trivial-garbage` over `sb-ext` for portability

### DIFF
--- a/anatevka-tests.asd
+++ b/anatevka-tests.asd
@@ -7,6 +7,7 @@
                #:fiasco
                #:uiop
                #:closer-mop
+               #:trivial-garbage
               )
   :perform (asdf:test-op (o s)
                          (uiop:symbol-call ':anatevka-tests

--- a/tests/blossom.lisp
+++ b/tests/blossom.lisp
@@ -201,7 +201,7 @@ NOTE: This macro automatically rescales the pairs in `COORDINATES' to reside at 
                    (with-simulation (simulation (*local-courier* dryad))
                      (anatevka::reset-logger)
                      (when (= 0 (mod i 50))
-                       (sb-ext:gc :full t))
+                       (trivial-garbage:gc :full t))
                      (sow-spacelike-graph dryad ',coordinates
                                           :offset ,border)
                      (multiple-value-bind (matching time)


### PR DESCRIPTION
Closes #39, h/t @Yehouda.