### PR TITLE
Allow for dryad to specify which node class it works with

### DIFF
--- a/src/dryad.lisp
+++ b/src/dryad.lisp
@@ -36,7 +36,7 @@
     :initform (make-hash-table :hash-function #'hash-address :test #'address=)
     :type hash-table
     :documentation "A map ADDRESS -> BOOLEAN which records whether a `BLOSSOM-NODE' has begun participating in matches.")
-   (node-type
+   (node-class
     :accessor dryad-node-class
     :initform 'blossom-node
     :type symbol

--- a/src/dryad.lisp
+++ b/src/dryad.lisp
@@ -35,7 +35,12 @@
     :accessor dryad-sprouted?
     :initform (make-hash-table :hash-function #'hash-address :test #'address=)
     :type hash-table
-    :documentation "A map ADDRESS -> BOOLEAN which records whether a `BLOSSOM-NODE' has begun participating in matches."))
+    :documentation "A map ADDRESS -> BOOLEAN which records whether a `BLOSSOM-NODE' has begun participating in matches.")
+   (node-type
+    :accessor dryad-node-class
+    :initform 'blossom-node
+    :type symbol
+    :documentation "The class identifier for nodes that this `DRYAD' works with. Can be a `BLOSSOM-NODE' or any subclass of `BLOSSOM-NODE'."))
   (:documentation "PROCESS responsible for the injection and ejection of nodes from the blossom algorithm."))
 
 ;;;
@@ -48,7 +53,7 @@
 
 NOTE: In the basic implementation, these messages must be waiting for the DRYAD on launch."
   (let* ((node-id (message-sow-id message))
-         (node-process (spawn-process 'blossom-node
+         (node-process (spawn-process (dryad-node-class dryad)
                                       :dryad (process-public-address dryad)
                                       :id node-id))
          (node-address (process-public-address node-process)))

--- a/src/dryad.lisp
+++ b/src/dryad.lisp
@@ -25,6 +25,12 @@
     :initarg :match-address
     :type address
     :documentation "The `ADDRESS' to which the `DRYAD' will send REAP messages.")
+   (node-class
+    :accessor dryad-node-class
+    :initarg :node-class
+    :initform 'blossom-node
+    :type symbol
+    :documentation "The class identifier for nodes that this `DRYAD' works with. Can be a `BLOSSOM-NODE' or any subclass of `BLOSSOM-NODE'.")
    ;; local state
    (ids
     :accessor dryad-ids
@@ -35,12 +41,7 @@
     :accessor dryad-sprouted?
     :initform (make-hash-table :hash-function #'hash-address :test #'address=)
     :type hash-table
-    :documentation "A map ADDRESS -> BOOLEAN which records whether a `BLOSSOM-NODE' has begun participating in matches.")
-   (node-class
-    :accessor dryad-node-class
-    :initform 'blossom-node
-    :type symbol
-    :documentation "The class identifier for nodes that this `DRYAD' works with. Can be a `BLOSSOM-NODE' or any subclass of `BLOSSOM-NODE'."))
+    :documentation "A map ADDRESS -> BOOLEAN which records whether a `BLOSSOM-NODE' has begun participating in matches."))
   (:documentation "PROCESS responsible for the injection and ejection of nodes from the blossom algorithm."))
 
 ;;;

--- a/tests/blossom.lisp
+++ b/tests/blossom.lisp
@@ -58,7 +58,8 @@
 (defgeneric sow-spacelike-graph (dryad coordinates &key offset)
   (:documentation "Given a LIST of spacelike `COORDINATES', sow them into the `DRYAD'. Before sowing, apply the INTEGER `OFFSET' and shift the coordinates to the surface code coordinate system using `SHIFT-COORDINATES'."))
 
-(defmethod sow-spacelike-graph ((dryad dryad) coordinates &key offset)
+(defmethod sow-spacelike-graph ((dryad dryad) coordinates
+                                &key (offset (error "Must provide offset.")))
   (loop :for (x y) :in coordinates
         ;; apply offset and shift to 'lattice coordinate system'
         :for (shifted-x shifted-y) := (shift-coordinates x y offset)
@@ -104,7 +105,7 @@
 
 (defmethod normalize-match ((id-a anatevka-tests::grid-location)
                             (id-b anatevka-tests::grid-location)
-                            &key offset)
+                            &key (offset (error "Must provide offset.")))
   (let* ((a-x (grid-location-x id-a))
          (a-y (grid-location-y id-a))
          (b-x (grid-location-x id-b))
@@ -126,8 +127,12 @@
          (loop :for coordinate :in coordinates
                :collect (contains-coordinate? matching coordinate))))
 
-(defun await-matching (simulation match-address
-                       &key coordinates offset timeout timestep)
+(defun await-matching (simulation
+                       match-address
+                       &key (coordinates (error "Must provide coordinates."))
+                            (offset (error "Must provide offset."))
+                            (timeout (error "Must provide timeout"))
+                            (timestep (error "Must provide timestep.")))
   "Run the `SIMULATION' and listen on the `MATCH-ADDRESS' for a series of reap messages that contain the matching produced by the blossom algorithm. The simulation runs, checking the channel every `TIMESTEP' steps, until it received a perfect matching (determined using the LIST of `COORDINATES'), or until hitting the `TIMEOUT' (an INTEGER). Each message is unpacked (using the `OFFSET') into a LIST of LISTs, and pushed onto the MATCHING (also a LIST), which is returned at the end, along with the time it took to complete."
   (initialize-and-return ((final-time) (matching))
     (loop :with time := 0


### PR DESCRIPTION
Also enforces that certain keyword arguments in the blossom test suite are required.