### PR TITLE
Associate macrovertices with the dryad of the source root

### DIFF
--- a/src/operations/contract.lisp
+++ b/src/operations/contract.lisp
@@ -99,6 +99,7 @@ PETAL-CHILD-EDGES: The list of child edges attached to the blossoms in the subtr
     (let* ((supervisor-frame (peek (process-data-stack supervisor)))
            (fresh-blossom (spawn-process (supervisor-node-class supervisor)
                                          :id (gensym "BLOSSOM")
+                                         :dryad (supervisor-node-dryad supervisor)
                                          ;; prevent SCANs
                                          :paused? t
                                          :debug? (process-debug? supervisor))))

--- a/src/operations/scan.lisp
+++ b/src/operations/scan.lisp
@@ -406,6 +406,7 @@ NOTE: this command is only installed when NODE is a vertex."
                  `(SCAN-LOOP nil)))
          (let ((supervisor (make-supervisor node
                                             :node-class (type-of node)
+                                            :node-dryad (blossom-node-dryad node)
                                             :debug? (process-debug? node))))
            (log-entry :entry-type 'spawn-supervisor
                       :pong pong

--- a/src/supervisor.lisp
+++ b/src/supervisor.lisp
@@ -32,8 +32,9 @@
     :type symbol)
    (node-dryad
     :accessor supervisor-node-dryad
+    :initform nil
     :initarg :node-dryad
-    :type address
+    :type (or null address)
     :documentation "The address of the host `DRYAD' for the node that spawned us."))
   (:documentation "A companion process responsible for coordinating a tree operation."))
 

--- a/src/supervisor.lisp
+++ b/src/supervisor.lisp
@@ -32,9 +32,8 @@
     :type symbol)
    (node-dryad
     :accessor supervisor-node-dryad
-    :initform nil
     :initarg :node-dryad
-    :type (or null address)
+    :type address
     :documentation "The address of the host `DRYAD' for the node that spawned us."))
   (:documentation "A companion process responsible for coordinating a tree operation."))
 

--- a/src/supervisor.lisp
+++ b/src/supervisor.lisp
@@ -29,7 +29,13 @@
     :accessor supervisor-node-class
     :initform 'blossom-node
     :initarg :node-class
-    :type symbol))
+    :type symbol)
+   (node-dryad
+    :accessor supervisor-node-dryad
+    :initform nil
+    :initarg :node-dryad
+    :type (or null address)
+    :documentation "The address of the host `DRYAD' for the node that spawned us."))
   (:documentation "A companion process responsible for coordinating a tree operation."))
 
 (define-message-dispatch supervisor


### PR DESCRIPTION
By storing the dryad address on the supervisor.