### PR TITLE
Update `tree-equalp` to scan all `blossom-node` slots

### DIFF
--- a/src/node.lisp
+++ b/src/node.lisp
@@ -52,6 +52,7 @@
    (pingable
     :accessor blossom-node-pingable
     :initform ':ALL
+    :initarg :pingable
     :type ping-type
     :documentation "Used by message handler guards to determine whether this process is currently servicing PING requests. SOFT-PINGs are serviced when set to :SOFT or :ALL, PINGs are serviced when set to :ALL, nothing is serviced when set to :NONE.")
    (wilting

--- a/tests/node.lisp
+++ b/tests/node.lisp
@@ -264,13 +264,13 @@ Finally, all of the nodes constructed by this BLOSSOM-LET are stashed in the pla
                   (equalp left-value right-value))))
              (blossom-slots (value)
                (initialize-and-return ((slots nil))
-                 (block quick-exit
+                 (block nil
                    (dolist (superclass (closer-mop:class-precedence-list (class-of value)))
                      (dolist (slot-definition (closer-mop:class-direct-slots superclass))
                        (push (closer-mop:slot-definition-name slot-definition) slots))
                      (when (equalp superclass (closer-mop:ensure-class
                                                'anatevka:blossom-node))
-                       (return-from quick-exit)))))))
+                       (return)))))))
       (loop :for left :in left-nodes
             :for right :in right-nodes
             :do (setf (gethash (process-public-address left) dictionary)


### PR DESCRIPTION
Also [Allow pingable to be set via an initarg](https://github.com/dtqec/anatevka/commit/0e9436121961083371868b4361cd01d97e3cb63a).