### PR TITLE
Include `target-root` in the `got-recommendation` log entry

### DIFF
--- a/src/operations/reweight.lisp
+++ b/src/operations/reweight.lisp
@@ -75,7 +75,7 @@
     ;; the contents of `targets' depend on the recommendation. it always
     ;; includes the `source-root', and additionally
     ;;  - `AUGMENT': the `target-root'
-    ;;  - `GRAFT': the barbell
+    ;;  - `GRAFT': one end of the barbell
     ;;  - `EXPAND' or `CONTRACT': nothing
     (let ((targets (remove-duplicates (list source-root target-root)
                                       :test #'address=)))

--- a/src/supervisor.lisp
+++ b/src/supervisor.lisp
@@ -77,6 +77,7 @@ PONG: The PONG that this process received at its START."
     (with-slots (edges weight source-root target-root recommendation) pong
       (log-entry :entry-type 'got-recommendation
                  :source-root source-root
+                 :target-root target-root
                  :recommendation recommendation
                  :weight weight
                  :edges edges)


### PR DESCRIPTION
[Also fix an error in a comment in reweight.lisp](https://github.com/dtqec/anatevka/commit/932d2db46da2f7d79544f89b5b89d48962372f67)