### PR TITLE
Add unit tests that flex dryad expansion

### DIFF
--- a/anatevka-tests.asd
+++ b/anatevka-tests.asd
@@ -17,6 +17,7 @@
   :components ((:file "package")
                (:file "suite")
                (:file "node")
+               (:file "dryad")
                (:module "operations"
                 :serial t
                 :components ((:file "graft")

--- a/src/dryad.lisp
+++ b/src/dryad.lisp
@@ -31,6 +31,12 @@
     :initform 'blossom-node
     :type symbol
     :documentation "The class identifier for nodes that this `DRYAD' works with. Can be a `BLOSSOM-NODE' or any subclass of `BLOSSOM-NODE'.")
+   (shuffle?
+    :accessor dryad-shuffle?
+    :initarg :shuffle?
+    :initform nil
+    :type boolean
+    :documentation "If T, the list of channels to try is shuffled before a `MESSAGE-DISCOVERY' is sent to the querying node.")
    ;; local state
    (ids
     :accessor dryad-ids
@@ -70,6 +76,8 @@ NOTE: In the basic implementation, these messages must be waiting for the DRYAD 
           (loop :for address :being :the :hash-keys :of (dryad-ids dryad)
                 :unless (address= address (message-discover-address message))
                   :collect address)))
+    (when (dryad-shuffle? dryad)
+      (setf channels (a:shuffle channels)))
     (send-message (message-reply-channel message)
                   (make-message-discovery :channels-to-try channels))))
 

--- a/src/operations/multireweight.lisp
+++ b/src/operations/multireweight.lisp
@@ -118,7 +118,8 @@ Then, we reach the \"critical segment\", where it becomes impossible to rewind p
 (define-process-upkeep ((supervisor supervisor) now)
     (CHECK-PRIORITY source-root target-roots)
   "Confirm that, of the roots in the hold cluster, we have priority to act. Namely, we have priority when our `SOURCE-ROOT' carries the minimum ID (i.e. coordinate) of all the roots in the `hold-cluster' (passed as `TARGET-ROOTS')."
-  (let ((hold-cluster target-roots))
+  ;; `target-roots' includes `source-root', so we begin by removing it
+  (let ((hold-cluster (remove source-root target-roots :test #'address=)))
     (sync-rpc (make-message-id-query) (source-id source-root)
       (with-replies (replies)
                     (send-message-batch #'make-message-id-query hold-cluster)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -35,6 +35,7 @@
    #:dryad-match-address                ; ACCESSOR
    #:dryad-ids                          ; ACCESSOR
    #:dryad-sprouted?                    ; ACCESSOR
+   #:dryad-shuffle?                     ; ACCESSOR
    #:vertex-vertex-distance             ; GENERIC FUNCTION
    
    ;; messages

--- a/tests/blossom.lisp
+++ b/tests/blossom.lisp
@@ -206,7 +206,9 @@ NOTE: This macro automatically rescales the pairs in `COORDINATES' to reside at 
                         (dryad (spawn-process ',dryad-class
                                               :process-clock-rate ,dryad-clock-rate
                                               :match-address channel
-                                              :debug? ,debug?)))
+                                              :debug? ,debug?
+                                              :shuffle? t))
+                        (*random-state* (sb-kernel::seed-random-state i)))
                    (with-simulation (simulation (*local-courier* dryad))
                      (anatevka::reset-logger)
                      (when (= 0 (mod i 50))

--- a/tests/dryad.lisp
+++ b/tests/dryad.lisp
@@ -1,0 +1,102 @@
+;;;; tests/dryad.lisp
+;;;;
+;;;; Tests dryad functionality: in particular the expansion of macrovertices at
+;;;; the termination of the blossom algorithm.
+
+(in-package #:anatevka-tests)
+
+(deftest test-dryad-expand-barbell-3-blossom ()
+  "Tests that a DRYAD will properly execute the following blossom expansion:
+
+        +
+     BLOSSOM         +             +     +     +     +
+ [A --- B --- C] === D     -->     A === B     C === D
+ [\-----------/]
+"
+  (with-with ((with-courier ())
+              (with-simulation (simulation (*local-courier*))))
+    (let* ((dryad (spawn-process 'dryad :match-address (register)
+                                        :debug? t))
+           (dryad-address (process-public-address dryad)))
+      (simulation-add-event simulation (make-event :callback dryad))
+      (blossom-let (original-tree :dryad dryad-address)
+          ((BLOSSOM :id (gensym "BLOSSOM")
+                    :match-edge (bb-edge BLOSSOM C D D)
+                    :petals (list (vv-edge A C)
+                                  (vv-edge C B)
+                                  (vv-edge B A)))
+           (A :id (id 0) :internal-weight 2 :pistil BLOSSOM)
+           (B :id (id 2) :pistil BLOSSOM)
+           (C :id (id 4) :internal-weight 2 :pistil BLOSSOM)
+           (D :id (id 6) :match-edge (bb-edge D D C BLOSSOM)))
+        (simulate-add-tree simulation original-tree :dryad dryad)
+        (simulate-until-dead simulation BLOSSOM :timeout 100)
+        (blossom-let (target-tree :dryad dryad-address)
+            ((BLOSSOM-new :id (slot-value BLOSSOM 'anatevka::id)
+                      :match-edge (bb-edge BLOSSOM-new C D D)
+                      :petals (list (vv-edge A C)
+                                    (vv-edge C B)
+                                    (vv-edge B A))
+                      :wilting t)
+             (A :id (id 0) :match-edge (vv-edge A B)
+                :internal-weight 2)
+             (B :id (id 2) :match-edge (vv-edge B A))
+             (C :id (id 4) :match-edge (vv-edge C D)
+                :internal-weight 2)
+             (D :id (id 6) :match-edge (vv-edge D C)))
+          (is (tree-equalp original-tree target-tree)))))))
+
+(deftest test-dryad-expand-barbell-5-blossom ()
+  "Tests that a DRYAD will properly execute the following blossom expansion:
+
+     +
+  BLOSSOM              +     +
+ [B --- C]             B === C
+ [|     |]
+ [|     |]
+ [A     |]        -->  A +
+ [|     |]             !
+ [|     |]             !     +     +
+ [D --- E] === F     + D     E === F
+"
+  (with-with ((with-courier ())
+              (with-simulation (simulation (*local-courier*))))
+    (let* ((dryad (spawn-process 'dryad :match-address (register)
+                                        :debug? t))
+           (dryad-address (process-public-address dryad)))
+      (simulation-add-event simulation (make-event :callback dryad))
+      (blossom-let (original-tree :dryad dryad-address)
+          ((BLOSSOM :id (gensym "BLOSSOM")
+                    :match-edge (bb-edge BLOSSOM E F F)
+                    :petals (list (vv-edge A D)
+                                  (vv-edge D E)
+                                  (vv-edge E C)
+                                  (vv-edge C B)
+                                  (vv-edge B A)))
+           (A :id (id 0 2) :internal-weight 2 :pistil BLOSSOM)
+           (B :id (id 0 4) :pistil BLOSSOM)
+           (C :id (id 2 4) :internal-weight 2 :pistil BLOSSOM)
+           (D :id (id 0 0) :pistil BLOSSOM)
+           (E :id (id 2 0) :internal-weight 2 :pistil BLOSSOM)
+           (F :id (id 4 0) :match-edge (bb-edge F F E BLOSSOM)))
+        (simulate-add-tree simulation original-tree :dryad dryad)
+        (simulate-until-dead simulation BLOSSOM :timeout 100)
+        (blossom-let (target-tree :dryad dryad-address)
+            ((BLOSSOM-new :id (slot-value BLOSSOM 'anatevka::id)
+                          :match-edge (bb-edge BLOSSOM-new E F F)
+                          :petals (list (vv-edge A D)
+                                        (vv-edge D E)
+                                        (vv-edge E C)
+                                        (vv-edge C B)
+                                        (vv-edge B A))
+                          :wilting t)
+             (A :id (id 0 2) :match-edge (vv-edge A D)
+                :internal-weight 2)
+             (B :id (id 0 4) :match-edge (vv-edge B C))
+             (C :id (id 2 4) :match-edge (vv-edge C B)
+                :internal-weight 2)
+             (D :id (id 0 0) :match-edge (vv-edge D A))
+             (E :id (id 2 0) :match-edge (vv-edge E F)
+                :internal-weight 2)
+             (F :id (id 4 0) :match-edge (vv-edge F E)))
+          (is (tree-equalp original-tree target-tree)))))))

--- a/tests/dryad.lisp
+++ b/tests/dryad.lisp
@@ -46,6 +46,68 @@
              (D :id (id 6) :match-edge (vv-edge D C)))
           (is (tree-equalp original-tree target-tree)))))))
 
+(deftest test-dryad-expand-barbell-3-blossom-x2 ()
+  "Tests that a DRYAD will properly execute the following blossom expansion:
+
+        +                   +
+     BLOSSOM             BLOSSOM2                +     +     +     +     +     +
+ [A --- B --- C] === [D --- E --- F]     -->     A === B     C === D     E === F
+ [\-----------/]     [\-----------/]
+"
+  (with-with ((with-courier ())
+              (with-simulation (simulation (*local-courier*))))
+    (let* ((dryad (spawn-process 'dryad :match-address (register)
+                                        :debug? t))
+           (dryad-address (process-public-address dryad)))
+      (simulation-add-event simulation (make-event :callback dryad))
+      (blossom-let (original-tree :dryad dryad-address)
+          ((BLOSSOM :id (gensym "BLOSSOM-A")
+                    :match-edge (bb-edge BLOSSOM C D BLOSSOM2)
+                    :petals (list (vv-edge A C)
+                                  (vv-edge C B)
+                                  (vv-edge B A)))
+           (BLOSSOM2 :id (gensym "BLOSSOM-B")
+                     :match-edge (bb-edge BLOSSOM2 D C BLOSSOM)
+                     :petals (list (vv-edge D F)
+                                   (vv-edge F E)
+                                   (vv-edge E D)))
+           (A :id (id 0) :internal-weight 2 :pistil BLOSSOM)
+           (B :id (id 2) :pistil BLOSSOM)
+           (C :id (id 4) :internal-weight 2 :pistil BLOSSOM)
+           (D :id (id 6) :pistil BLOSSOM2)
+           (E :id (id 8) :internal-weight 2 :pistil BLOSSOM2)
+           (F :id (id 10) :pistil BLOSSOM2)
+           )
+        (simulate-add-tree simulation original-tree :dryad dryad)
+        (simulate-until-dead simulation BLOSSOM :timeout 100)
+        (simulate-until-dead simulation BLOSSOM2 :timeout 100)
+        (blossom-let (target-tree :dryad dryad-address)
+            ((BLOSSOM-new :id (slot-value BLOSSOM 'anatevka::id)
+                          :match-edge (bb-edge BLOSSOM-new C D D)
+                          :petals (list (vv-edge A C)
+                                        (vv-edge C B)
+                                        (vv-edge B A))
+                          :wilting t)
+             ;; nb: the match-edge here still has the other macrovertex in it
+             ;;     which probably means that BLOSSOM2 was popped first
+             (BLOSSOM2-new :id (slot-value BLOSSOM2 'anatevka::id)
+                           :match-edge (bb-edge BLOSSOM2-new D C BLOSSOM-new)
+                           :petals (list (vv-edge D F)
+                                         (vv-edge F E)
+                                         (vv-edge E D))
+                           :wilting t
+                           )
+             (A :id (id 0) :match-edge (vv-edge A B)
+                :internal-weight 2)
+             (B :id (id 2) :match-edge (vv-edge B A))
+             (C :id (id 4) :match-edge (vv-edge C D)
+                :internal-weight 2)
+             (D :id (id 6) :match-edge (vv-edge D C))
+             (E :id (id 8) :internal-weight 2 :match-edge (vv-edge E F))
+             (F :id (id 10) :match-edge (vv-edge F E))
+             )
+          (is (tree-equalp original-tree target-tree)))))))
+
 (deftest test-dryad-expand-barbell-5-blossom ()
   "Tests that a DRYAD will properly execute the following blossom expansion:
 

--- a/tests/dryad.lisp
+++ b/tests/dryad.lisp
@@ -108,6 +108,69 @@
              )
           (is (tree-equalp original-tree target-tree)))))))
 
+(deftest test-dryad-expand-barbell-3-blossom-nested ()
+  "Tests that a DRYAD will properly execute the following blossom expansion:
+
+      BLOSSOM
+ [[A --- B --- C] ---  D --- E] === F     -->     A === B     C === D     E === F
+  [\-----------/]
+ [\--------------------------/]
+             BLOSSOM2
+"
+  (with-with ((with-courier ())
+              (with-simulation (simulation (*local-courier*))))
+    (let* ((dryad (spawn-process 'dryad :match-address (register)
+                                        :debug? t))
+           (dryad-address (process-public-address dryad)))
+      (simulation-add-event simulation (make-event :callback dryad))
+      (blossom-let (original-tree :dryad dryad-address)
+          ((BLOSSOM :id (gensym "BLOSSOM-A")
+                    :pistil BLOSSOM2
+                    :petals (list (vv-edge A C)
+                                  (vv-edge C B)
+                                  (vv-edge B A)))
+           (BLOSSOM2 :id (gensym "BLOSSOM-B")
+                     :match-edge (bb-edge BLOSSOM2 E F F)
+                     :petals (list (bb-edge BLOSSOM C E E)
+                                   (vv-edge E D)
+                                   (bb-edge D D C BLOSSOM)))
+           (A :id (id 0) :internal-weight 2 :pistil BLOSSOM)
+           (B :id (id 2) :pistil BLOSSOM)
+           (C :id (id 4) :internal-weight 2 :pistil BLOSSOM)
+           (D :id (id 6) :pistil BLOSSOM2)
+           (E :id (id 8) :internal-weight 2 :pistil BLOSSOM2)
+           (F :id (id 10)
+              :match-edge (bb-edge F F E BLOSSOM2)
+              )
+           )
+        (simulate-add-tree simulation original-tree :dryad dryad)
+        (simulate-until-dead simulation BLOSSOM2 :timeout 100)
+        (simulate-until-dead simulation BLOSSOM :timeout 100)
+        (blossom-let (target-tree :dryad dryad-address)
+            ((BLOSSOM-new :id (slot-value BLOSSOM 'anatevka::id)
+                          :match-edge (bb-edge BLOSSOM-new C D D)
+                          :petals (list (vv-edge A C)
+                                        (vv-edge C B)
+                                        (vv-edge B A))
+                          :wilting t)
+             (BLOSSOM2-new :id (slot-value BLOSSOM2 'anatevka::id)
+                           :match-edge (bb-edge BLOSSOM2-new E F F)
+                           :petals (list (bb-edge BLOSSOM-new C E E)
+                                   (vv-edge E D)
+                                   (bb-edge D D C BLOSSOM-new))
+                           :wilting t
+                           )
+             (A :id (id 0) :match-edge (vv-edge A B)
+                :internal-weight 2)
+             (B :id (id 2) :match-edge (vv-edge B A))
+             (C :id (id 4) :match-edge (vv-edge C D)
+                :internal-weight 2)
+             (D :id (id 6) :match-edge (vv-edge D C))
+             (E :id (id 8) :internal-weight 2 :match-edge (vv-edge E F))
+             (F :id (id 10) :match-edge (vv-edge F E))
+             )
+          (is (tree-equalp original-tree target-tree)))))))
+
 (deftest test-dryad-expand-barbell-5-blossom ()
   "Tests that a DRYAD will properly execute the following blossom expansion:
 

--- a/tests/node.lisp
+++ b/tests/node.lisp
@@ -214,10 +214,16 @@ Finally, all of the nodes constructed by this BLOSSOM-LET are stashed in the pla
                                       '(list '(anatevka::IDLE)))))
            ,@body)))))
 
-(defun simulate-add-tree (simulation tree &key (start-time 0))
-  "BLOSSOM-LET binds a place that knows about all the nodes it's constructed, called the \"tree\".  SIMULATE-ADD-TREE takes the contents of this place and adds it to a SIMULATION object."
+(defun simulate-add-tree (simulation tree &key (start-time 0) (dryad nil) (sprouted? t))
+  "BLOSSOM-LET binds a place that knows about all the nodes it's constructed, called the \"tree\". SIMULATE-ADD-TREE takes the contents of this place and adds it to a SIMULATION object. If a `DRYAD' is provided, we set its slots for each node."
   (dolist (node tree)
-    (simulation-add-event simulation (make-event :callback node :time start-time))))
+    (simulation-add-event simulation (make-event :callback node :time start-time))
+    (when dryad
+      (unless (anatevka::blossom-node-petals node)
+        (let ((id (slot-value node 'anatevka::id))
+              (address (process-public-address node)))
+          (setf (gethash address (dryad-ids dryad))         id
+                (gethash address (dryad-sprouted? dryad))   sprouted?))))))
 
 (defun simulate-until-dead (simulation process &key (start-time 0) timeout)
   "Runs SIMULATION until PROCESS exhausts its command queue."

--- a/tests/node.lisp
+++ b/tests/node.lisp
@@ -222,8 +222,8 @@ Finally, all of the nodes constructed by this BLOSSOM-LET are stashed in the pla
       (unless (anatevka::blossom-node-petals node)
         (let ((id (slot-value node 'anatevka::id))
               (address (process-public-address node)))
-          (setf (gethash address (dryad-ids dryad))         id
-                (gethash address (dryad-sprouted? dryad))   sprouted?))))))
+          (setf (gethash address (dryad-ids dryad))        id
+                (gethash address (dryad-sprouted? dryad))  sprouted?))))))
 
 (defun simulate-until-dead (simulation process &key (start-time 0) timeout)
   "Runs SIMULATION until PROCESS exhausts its command queue."

--- a/tests/node.lisp
+++ b/tests/node.lisp
@@ -214,7 +214,7 @@ Finally, all of the nodes constructed by this BLOSSOM-LET are stashed in the pla
                                       '(list '(anatevka::IDLE)))))
            ,@body)))))
 
-(defun simulate-add-tree (simulation tree &key (start-time 0) (dryad nil) (sprouted? t))
+(defun simulate-add-tree (simulation tree &key (start-time 0) dryad (sprouted? t))
   "BLOSSOM-LET binds a place that knows about all the nodes it's constructed, called the \"tree\". SIMULATE-ADD-TREE takes the contents of this place and adds it to a SIMULATION object. If a `DRYAD' is provided, we set its slots for each node."
   (dolist (node tree)
     (simulation-add-event simulation (make-event :callback node :time start-time))


### PR DESCRIPTION
Also
* [Modify simulate-add-tree to accept and populate a dryad](https://github.com/dtqec/anatevka/commit/29856eac0a28f955d76b81f410e7145055b99712)
* [Add shuffle? slot to dryads for shuffling discovery channels](https://github.com/dtqec/anatevka/commit/eb19ef510c50d96c2f2b295f752872d525d5836c)
* [Set shuffle? to T in blossom tests & set random seed for reproducibility](https://github.com/dtqec/anatevka/commit/28f73d228661cce3cb75e17e85f23082877b505e)
* [Remove source-root from hold-cluster for CHECK-PRIORITY](https://github.com/dtqec/anatevka/commit/1cfa69e3a3eef65cf86c7606a6cbe6847c9fa01c)