### PR TITLE
Check for tree structure in `SPROUTS-LOOP`; send wilts in `PROCESS-PAIRS`

### DIFF
--- a/src/dryad.lisp
+++ b/src/dryad.lisp
@@ -130,8 +130,11 @@ NOTE: In the basic implementation, these messages must be waiting for the DRYAD 
 (define-process-upkeep ((dryad dryad) now) (SPROUTS-LOOP)
   "Loop over sprouted nodes, looking for ripe pairs."
   ;; if not everyone is sprouted, hold off
-  (unless (loop :for sprouted? :in (a:hash-table-values (dryad-sprouted? dryad))
-                :always sprouted?)
+  ;; NB: the loop returns T if the hash table is empty, so we additionally
+  ;;     guard against that
+  (unless (and (a:hash-table-values (dryad-sprouted? dryad))
+               (loop :for sprouted? :in (a:hash-table-values (dryad-sprouted? dryad))
+                     :always sprouted?))
     (process-continuation dryad `(SPROUTS-LOOP))
     (finish-with-scheduling))
   (let ((addresses (a:hash-table-keys (dryad-sprouted? dryad))))

--- a/src/dryad.lisp
+++ b/src/dryad.lisp
@@ -132,7 +132,7 @@ NOTE: In the basic implementation, these messages must be waiting for the DRYAD 
   ;; if not everyone is sprouted, hold off
   ;; NB: the loop returns T if the hash table is empty, so we additionally
   ;;     guard against that
-  (unless (and (a:hash-table-values (dryad-sprouted? dryad))
+  (unless (and (plusp (hash-table-count (dryad-sprouted? dryad)))
                (loop :for sprouted? :in (a:hash-table-values (dryad-sprouted? dryad))
                      :always sprouted?))
     (process-continuation dryad `(SPROUTS-LOOP))
@@ -159,6 +159,8 @@ NOTE: In the basic implementation, these messages must be waiting for the DRYAD 
                                             `(SPROUTS-LOOP))
                       (finish-with-scheduling))
           ;; if we're in the middle of an augment, we should pause for a bit
+          ;; NB: it is deliberate that we defer this to after the loop, so that we
+          ;;     might prefer to SEND-EXPAND vs. just waiting bc of an augment
           (when mid-augment?
             (process-continuation dryad
                                   `(SPROUTS-LOOP))

--- a/src/dryad.lisp
+++ b/src/dryad.lisp
@@ -69,6 +69,9 @@ NOTE: In the basic implementation, these messages must be waiting for the DRYAD 
                                       :id node-id
                                       :debug? (process-debug? dryad)))
          (node-address (process-public-address node-process)))
+    (log-entry :entry-type 'handling-sow
+               :address node-address
+               :id node-id)
     (schedule node-process now)
     (setf (gethash node-address (dryad-ids       dryad)) node-id
           (gethash node-address (dryad-sprouted? dryad)) nil)))
@@ -91,7 +94,10 @@ NOTE: In the basic implementation, these messages must be waiting for the DRYAD 
     ((dryad dryad) (message message-sprout) now)
   "Handles a SPROUT message, indicating that a BLOSSOM-NODE has been matched (for the first time)."
   (with-slots (address) message
-    (when (gethash address (dryad-ids dryad))
+    (a:when-let ((id (gethash address (dryad-ids dryad))))
+      (log-entry :entry-type 'handling-sprout
+                 :address address
+                 :id id)
       (setf (gethash address (dryad-sprouted? dryad)) t))))
 
 (define-rpc-handler handler-message-wilting

--- a/src/logger.lisp
+++ b/src/logger.lisp
@@ -101,11 +101,17 @@
              (and (eql 'SUPERVISOR (getf entry ':source-type))
                   (eql 'MULTIREWEIGHTING (getf entry ':entry-type)))
              (and (eql 'MESSAGE-WILT (type-of (getf entry ':payload))))
-             (and (eql 'HANDLING-SOW (getf entry ':entry-type)))
-             ;; dryad expansion
-             (and (eql 'COMMAND (getf entry ':entry-type))
-                  (eql 'SEND-EXPAND (getf entry ':command)))
-             (and (eql 'DRYAD-SENDING-EXPAND (getf entry ':entry-type)))
              (and (eql 'SPAWNED-FRESH-BLOSSOM (getf entry ':entry-type)))
              (and (eql 'BLOSSOM-EXTINGUISHED (getf entry ':entry-type))))
+         (push entry entries))
+        ;; dryad logs
+        ((and (eql 'DRYAD (getf entry ':source-type))
+              ;; dryad sowing
+              (or (eql 'HANDLING-SOW (getf entry ':entry-type))
+                  (eql 'HANDLING-SPROUT (getf entry ':entry-type))
+                  (eql 'PROCESSING-PAIR (getf entry ':entry-type))
+                  ;; dryad expansion
+                  (and (eql 'COMMAND (getf entry ':entry-type))
+                       (eql 'SEND-EXPAND (getf entry ':command)))
+                  (eql 'DRYAD-SENDING-EXPAND (getf entry ':entry-type))))
          (push entry entries))))))


### PR DESCRIPTION
Summary of changes:

1. Check for tree structure in `SPROUTS-LOOP`. If we encounter tree structure that means an `AUGMENT` is still wrapping up, so we hold off on proceeding to `PROCESS-PAIRS`. Otherwise a wilt message would raise an error, because it double-checks that the wilting node is not part of a tree. This happens because we set the `sprouted?` table faster than we dissemble the tree structure during an `AUGMENT`.
2. Change `PROCESS-PAIRS` so that it takes a list of list of addresses rather than `ID`s. This allows us to send wilt messages in `PROCESS-PAIRS` without having to message the nodes in question (thanks to the `dryad-ids` table). We "should" have been doing this all along ("should" because wilting is not super important in the offline case, but helpful for ensuring validity). 
3. Add some more dryad-related log entries and increase verbosity of `reduce-log` to make it actually useful for debugging. For example, somehow the `'handling-sow` event type was not making it into the reduced log.
4. Guard against the possibility of an empty `sprouts?` hash table in `SPROUTS-LOOP`. This is important if the dryad starts up in advance of the first round of sow messages -- it is possible for it to make it past the `:always sprouted?` guard and jump right into `WIND-DOWN` and die.