### PR TITLE
Multi-cluster multireweight and discovery blackjack

### DIFF
--- a/src/dryad-api.lisp
+++ b/src/dryad-api.lisp
@@ -17,12 +17,15 @@
 
 ;;; messages between the dryad and its managed blossoms
 
+(deftype discover-strategy ()
+  '(member :BUST :HIT :STAY))
+
 (defstruct (message-discover (:include message))
   "Sent from a blossom process to a `DRYAD' to query for a list of other blossom processes to which it should send PINGs."
   (address         nil :type address)
   (id              nil :type t)
   (internal-weight nil :type real) ; NOTE: a little surprised that this isn't (REAL 0)
-  (repeat?         nil :type boolean)) 
+  (strategy        nil :type (or null discover-strategy)))
 
 (defstruct (message-discovery (:include message)
                               (:constructor %make-message-discovery))

--- a/src/dryad-api.lisp
+++ b/src/dryad-api.lisp
@@ -25,7 +25,7 @@
   (address         nil :type address)
   (id              nil :type t)
   (internal-weight nil :type real) ; NOTE: a little surprised that this isn't (REAL 0)
-  (strategy        nil :type (or null discover-strategy)))
+  (strategy        nil :type discover-strategy))
 
 (defstruct (message-discovery (:include message)
                               (:constructor %make-message-discovery))

--- a/src/node.lisp
+++ b/src/node.lisp
@@ -466,7 +466,7 @@ evalutes to
     (let ((scan-message (make-message-scan
                          :local-root (process-public-address node)
                          :weight 0
-                         :strategy (if repeat? :HIT :BUST))))
+                         :strategy (if repeat? ':HIT ':BUST))))
       (process-continuation node `(START-SCAN ,scan-message)))))
 
 (define-process-upkeep ((node blossom-node)) (IDLE)

--- a/src/node.lisp
+++ b/src/node.lisp
@@ -262,13 +262,6 @@ evalutes to
   (slot  nil :type symbol)
   (value nil :type t))
 
-;; TODO: probably just delete this, I don't think it's needed anymore
-(defstruct (message-change (:include message))
-  "Causes a remote SETF (on the BLOSSOM-NODE object) iff the provided VALUE differs from the value stored in SLOT for that object. Uses TEST to determine equality."
-  (slot  nil :type symbol)
-  (value nil :type t)
-  (test #'eq :type function))
-
 (defstruct (message-values (:include message))
   "Replies with slot-values (on the BLOSSOM-NODE object)."
   (values nil :type list))
@@ -347,15 +340,6 @@ evalutes to
     (push value (slot-value node slot))
     (values)))
 
-(define-rpc-handler handle-message-change
-    ((node blossom-node) (message message-change))
-  "Handles a remote change request."
-  (with-slots (slot value test) message
-    (let ((same? (funcall test (slot-value node slot) value)))
-      (unless same?
-        (setf (slot-value node slot) value))
-      same?)))
-
 (define-rpc-handler handle-message-values
     ((node blossom-node) (message message-values))
   "Handles a remote request for data."
@@ -429,7 +413,6 @@ evalutes to
   
   (message-set                        'handle-message-set)
   (message-push                       'handle-message-push)
-  (message-change                     'handle-message-change)
   (message-values                     'handle-message-values)
   
   (message-root-path                  'handle-message-root-path)

--- a/src/node.lisp
+++ b/src/node.lisp
@@ -483,7 +483,7 @@ evalutes to
     (let ((scan-message (make-message-scan
                          :local-root (process-public-address node)
                          :weight 0
-                         :repeat? repeat?)))
+                         :strategy (if repeat? :HIT :BUST))))
       (process-continuation node `(START-SCAN ,scan-message)))))
 
 (define-process-upkeep ((node blossom-node)) (IDLE)

--- a/src/operations/multireweight.lisp
+++ b/src/operations/multireweight.lisp
@@ -105,15 +105,16 @@ Then, we reach the \"critical segment\", where it becomes impossible to rewind p
           ;; otherwise, push the next set of commands onto the stack
           (process-continuation supervisor
                                 `(CHECK-PRIORITY ,source-root ,hold-cluster)
-                                `(BROADCAST-LOCK ,hold-cluster)
-                                `(CHECK-ROOTS ,hold-cluster)
-                                `(BROADCAST-PINGABILITY ,hold-cluster :SOFT)
+                                #+i`(PAUSE-CLUSTER ,source-root ,hold-cluster)
                                 `(MULTIREWEIGHT-BROADCAST-SCAN ,hold-cluster)
-                                `(BROADCAST-PINGABILITY ,hold-cluster :NONE)
-                                `(MULTIREWEIGHT-BROADCAST-REWEIGHT ,hold-cluster)
-                                `(BROADCAST-PINGABILITY ,hold-cluster :SOFT)
-                                `(MULTIREWEIGHT-CHECK-REWINDING ,hold-cluster)
-                                `(BROADCAST-UNLOCK)))))))
+                                #+i`(BROADCAST-LOCK ,hold-cluster)
+                                #+i`(CHECK-ROOTS ,hold-cluster)
+                                #+i`(BROADCAST-PINGABILITY ,hold-cluster :SOFT)
+                                #+i`(BROADCAST-PINGABILITY ,hold-cluster :NONE)
+                                #+i`(MULTIREWEIGHT-BROADCAST-REWEIGHT ,hold-cluster)
+                                #+i`(BROADCAST-PINGABILITY ,hold-cluster :SOFT)
+                                #+i`(MULTIREWEIGHT-CHECK-REWINDING ,hold-cluster)
+                                #+i`(BROADCAST-UNLOCK)))))))
 
 (define-process-upkeep ((supervisor supervisor))
     (CHECK-PRIORITY source-root target-roots)
@@ -131,13 +132,30 @@ Then, we reach the \"critical segment\", where it becomes impossible to rewind p
                        :hold-cluster hold-cluster)
             (setf (process-lockable-aborting? supervisor) t)))))))
 
+#+i(define-process-upkeep ((supervisor supervisor))
+    (PAUSE-CLUSTER source-root target-roots)
+  "Set paused? to T for all roots in the hold cluster (`TARGET-ROOTS' - `SOURCE-ROOT'), iff they are not already paused. If they are paused, abort."
+  ;; `target-roots' includes `source-root', so we begin by removing it
+  (let ((hold-cluster (remove source-root target-roots :test #'address=)))
+    (flet ((payload-constructor ()
+             (make-message-change :slot 'paused? :value t)))
+      (with-replies (replies)
+                    (send-message-batch #'payload-constructor hold-cluster)
+        (format t "pause-cluster replies: ~a~%" replies)
+        (unless (every #'identity replies)
+          (log-entry :entry-type 'aborting-multireweight
+                     :reason 'other-roots-are-paused
+                     :source-root source-root
+                     :hold-cluster hold-cluster)
+          (setf (process-lockable-aborting? supervisor) t))))))
+
 (define-process-upkeep ((supervisor supervisor))
     (MULTIREWEIGHT-BROADCAST-SCAN roots)
   "Now that we know the full `HOLD-CLUSTER', we `SCAN' each, and aggregate the results in order to make a reweighting decision."
   (unless (process-lockable-aborting? supervisor)
     (with-slots (internal-pong) (peek (process-data-stack supervisor))
       (flet ((payload-constructor ()
-               (make-message-soft-scan :weight 0 :internal-roots roots :repeat? t)))
+               (make-message-scan :weight 0 :internal-roots roots :repeat? t)))
         (with-replies (replies
                        :returned? returned?
                        :message-type message-pong
@@ -146,7 +164,21 @@ Then, we reach the \"critical segment\", where it becomes impossible to rewind p
           (loop :for reply :in replies :unless (null reply)
                 :do (assert (not (minusp (message-pong-weight reply))))
                     (setf internal-pong
-                          (unify-pongs internal-pong reply))))))))
+                          (unify-pongs internal-pong reply)))
+          #+i(format t "(~a) [~a] {~a}: internal-pong: ~a~%" (now) supervisor roots internal-pong)
+          (with-slots (target-root) internal-pong
+            (let ((targets (remove-duplicates (append roots (list target-root))
+                                              :test #'address=)))
+              (process-continuation supervisor
+                                    `(BROADCAST-LOCK ,targets)
+                                    `(CHECK-ROOTS ,roots)
+                                    ;; could do a check-reweight here
+                                    #+i`(BROADCAST-PINGABILITY ,hold-cluster :SOFT)
+                                    #+i`(BROADCAST-PINGABILITY ,hold-cluster :NONE)
+                                    `(MULTIREWEIGHT-BROADCAST-REWEIGHT ,roots)
+                                    `(BROADCAST-PINGABILITY ,targets :SOFT)
+                                    `(MULTIREWEIGHT-CHECK-REWINDING ,roots)
+                                    `(BROADCAST-UNLOCK)))))))))
 
 (define-process-upkeep ((supervisor supervisor))
     (MULTIREWEIGHT-BROADCAST-REWEIGHT roots)
@@ -154,6 +186,7 @@ Then, we reach the \"critical segment\", where it becomes impossible to rewind p
   (unless (process-lockable-aborting? supervisor)
     (with-slots (internal-pong) (peek (process-data-stack supervisor))
       (let ((amount (message-pong-weight internal-pong)))
+        #+i(format t "(~a) [~a]: multireweighting with rec ~a~%" (now) supervisor internal-pong)
         (log-entry :entry-type 'multireweighting
                    :recommendation (message-pong-recommendation internal-pong)
                    :amount amount

--- a/src/operations/multireweight.lisp
+++ b/src/operations/multireweight.lisp
@@ -134,9 +134,9 @@ After collecting the `HOLD-CLUSTER', we then `CHECK-PRIORITY' to determine if we
 
 1. Lock the `TARGETS' (the `HOLD-CLUSTER' and potentially an external `TARGET-ROOT').
 2. Check that each root in the `HOLD-CLUSTER' is still a root.
-3. (TODO) Change the pingability of the `TARGETS' to `:SOFT'.
-4. (TODO) Check that our multireweight recommendation is still valid.
-5. (TODO) Change the pingability of the `TARGETS' to `:NONE'.
+3. Change the pingability of the `TARGETS' to `:SOFT'.
+4. Check that our multireweight recommendation is still valid.
+5. Change the pingability of the `TARGETS' to `:NONE'.
 6. Reweight the `HOLD-CLUSTER' according to the recommendation.
 7. Change the pingability of the `TARGETS' to `:SOFT'.
 8. Check to see if the `HOLD-CLUSTER' should be rewound, and do so if need be.
@@ -149,9 +149,9 @@ After collecting the `HOLD-CLUSTER', we then `CHECK-PRIORITY' to determine if we
           (process-continuation supervisor
                                 `(BROADCAST-LOCK ,targets)
                                 `(CHECK-ROOTS ,hold-cluster)
-                                #+i`(BROADCAST-PINGABILITY ,targets :SOFT)
-                                #+i`(CHECK-REWEIGHT ,hold-cluster ,internal-pong)
-                                #+i`(BROADCAST-PINGABILITY ,targets :NONE)
+                                `(BROADCAST-PINGABILITY ,targets :SOFT)
+                                `(CHECK-REWEIGHT ,hold-cluster ,internal-pong)
+                                `(BROADCAST-PINGABILITY ,targets :NONE)
                                 `(MULTIREWEIGHT-BROADCAST-REWEIGHT ,hold-cluster)
                                 `(BROADCAST-PINGABILITY ,targets :SOFT)
                                 `(MULTIREWEIGHT-CHECK-REWINDING ,hold-cluster)

--- a/src/operations/multireweight.lisp
+++ b/src/operations/multireweight.lisp
@@ -149,9 +149,9 @@ After collecting the `HOLD-CLUSTER', we then `CHECK-PRIORITY' to determine if we
           (process-continuation supervisor
                                 `(BROADCAST-LOCK ,targets)
                                 `(CHECK-ROOTS ,hold-cluster)
-                                #+i`(BROADCAST-PINGABILITY ,hold-cluster :SOFT)
-                                ;; TODO: could do a check-reweight variant here
-                                #+i`(BROADCAST-PINGABILITY ,hold-cluster :NONE)
+                                #+i`(BROADCAST-PINGABILITY ,targets :SOFT)
+                                #+i`(CHECK-REWEIGHT ,hold-cluster ,internal-pong)
+                                #+i`(BROADCAST-PINGABILITY ,targets :NONE)
                                 `(MULTIREWEIGHT-BROADCAST-REWEIGHT ,hold-cluster)
                                 `(BROADCAST-PINGABILITY ,targets :SOFT)
                                 `(MULTIREWEIGHT-CHECK-REWINDING ,hold-cluster)

--- a/src/operations/multireweight.lisp
+++ b/src/operations/multireweight.lisp
@@ -155,7 +155,7 @@ Then, we reach the \"critical segment\", where it becomes impossible to rewind p
   (unless (process-lockable-aborting? supervisor)
     (with-slots (internal-pong) (peek (process-data-stack supervisor))
       (flet ((payload-constructor ()
-               (make-message-scan :weight 0 :internal-roots roots :repeat? t)))
+               (make-message-scan :weight 0 :internal-roots roots :strategy :STAY)))
         (with-replies (replies
                        :returned? returned?
                        :message-type message-pong

--- a/src/operations/multireweight.lisp
+++ b/src/operations/multireweight.lisp
@@ -116,7 +116,7 @@ After collecting the `HOLD-CLUSTER', we then `CHECK-PRIORITY' to determine if we
   (unless (process-lockable-aborting? supervisor)
     (with-slots (internal-pong) (peek (process-data-stack supervisor))
       (flet ((payload-constructor ()
-               (make-message-scan :weight 0 :internal-roots roots :strategy :STAY)))
+               (make-message-scan :weight 0 :internal-roots roots :strategy ':STAY)))
         (with-replies (replies
                        :returned? returned?
                        :message-type message-pong

--- a/src/operations/reweight.lisp
+++ b/src/operations/reweight.lisp
@@ -106,6 +106,9 @@
           (message-pong
            (unregister listen-channel)
            (when (< (message-pong-weight pong-message) weight)
+             (log-entry :entry-type 'check-reweight-aborting
+                        :original-pong pong
+                        :check-pong pong-message)
              (setf (process-lockable-aborting? supervisor) t))))))))
 
 (define-process-upkeep ((supervisor supervisor))

--- a/src/operations/reweight.lisp
+++ b/src/operations/reweight.lisp
@@ -101,7 +101,7 @@
                                    :reply-channel listen-channel
                                    :local-root source-root
                                    :weight 0
-                                   :repeat? t))
+                                   :strategy :STAY))
         (sync-receive (listen-channel pong-message)
           (message-pong
            (unregister listen-channel)
@@ -129,7 +129,7 @@
     (let ((rewinding-pong nil)
           (original-amount (message-pong-weight original-pong)))
       (flet ((payload-constructor ()
-               (make-message-soft-scan :weight 0 :repeat? t)))
+               (make-message-soft-scan :weight 0 :strategy :STAY)))
         (with-replies (replies
                        :returned? returned?
                        :message-type message-pong

--- a/src/operations/reweight.lisp
+++ b/src/operations/reweight.lisp
@@ -100,7 +100,7 @@
       (flet ((payload-constructor ()
                (make-message-soft-scan :weight 0
                                        :internal-roots roots
-                                       :strategy :STAY)))
+                                       :strategy ':STAY)))
         (with-replies (replies
                        :message-type message-pong
                        :message-unpacker identity)
@@ -134,7 +134,7 @@
     (let ((rewinding-pong nil)
           (original-amount (message-pong-weight original-pong)))
       (flet ((payload-constructor ()
-               (make-message-soft-scan :weight 0 :strategy :STAY)))
+               (make-message-soft-scan :weight 0 :strategy ':STAY)))
         (with-replies (replies
                        :returned? returned?
                        :message-type message-pong

--- a/src/operations/reweight.lisp
+++ b/src/operations/reweight.lisp
@@ -117,6 +117,9 @@
     (BROADCAST-REWEIGHT roots weight)
   "Instruct some `ROOTS' to reweight their trees by `WEIGHT'."
   (unless (process-lockable-aborting? supervisor)
+    (log-entry :entry-type 'reweighting
+               :weight weight
+               :roots roots)
     (flet ((payload-constructor ()
              (make-message-broadcast-reweight :weight weight)))
       (with-replies (replies) (send-message-batch #'payload-constructor roots)

--- a/src/operations/reweight.lisp
+++ b/src/operations/reweight.lisp
@@ -61,15 +61,16 @@
   "Sets up the reweight procedure.
 
 1. Lock the targets.
-2. Change their pingability to `:SOFT'.
-3. Check for a weightless edge. Abort if found.
-4. Change the pingability of the targets to `:NONE'.
-5. Reweight the `source-root' by the `weight' of the `pong'.
-6. Change the pingability of the targets to `:SOFT'.
-7. Check if reweighting the `source-root' resulted in a negative-weight edge.
+2. Check that the `source-root' is still a root.
+3. Change their pingability to `:SOFT'.
+4. Check for a weightless edge. Abort if found.
+5. Change the pingability of the targets to `:NONE'.
+6. Reweight the `source-root' by the `weight' of the `pong'.
+7. Change the pingability of the targets to `:SOFT'.
+8. Check if reweighting the `source-root' resulted in a negative-weight edge.
     a. If so, and this is the second time we've been here, rewind fully.
     b. Otherwise, if so, rewind the reweighting by half and go back to (7).
-8. Unlock the targets.
+9. Unlock the targets.
 "
   (with-slots (source-root target-root weight) pong
     ;; the contents of `targets' depend on the recommendation. it always
@@ -84,7 +85,6 @@
                             `(CHECK-ROOTS (,source-root))
                             `(BROADCAST-PINGABILITY ,targets :SOFT)
                             `(CHECK-REWEIGHT (,source-root) ,pong)
-                            ;; it bugs me a bit having to switch this back & forth
                             `(BROADCAST-PINGABILITY ,targets :NONE)
                             `(BROADCAST-REWEIGHT (,source-root) ,weight)
                             `(BROADCAST-PINGABILITY ,targets :SOFT)
@@ -98,7 +98,9 @@
     (let ((check-pong nil)
           (original-weight (message-pong-weight original-pong)))
       (flet ((payload-constructor ()
-               (make-message-soft-scan :weight 0 :strategy :STAY)))
+               (make-message-soft-scan :weight 0
+                                       :internal-roots roots
+                                       :strategy :STAY)))
         (with-replies (replies
                        :message-type message-pong
                        :message-unpacker identity)

--- a/src/operations/scan.lisp
+++ b/src/operations/scan.lisp
@@ -70,7 +70,7 @@ Most of the slots are self-explanatory.  As an exception, ROOT-BUCKET aggregates
   (local-blossom  nil :type (or null address))
   (weight         nil :type real)
   (internal-roots nil :type list)
-  (strategy       nil :type (or null discover-strategy)))
+  (strategy       nil :type discover-strategy))
 
 (defstruct (message-soft-scan (:include message-scan))
   "The same as a SCAN, but it generates soft PINGs.")
@@ -202,7 +202,7 @@ When INTERNAL-ROOT-SET is supplied, discard HOLD recommendations which emanate f
   (petals         nil :type list)
   (weight         nil :type real)
   (internal-roots nil :type list)
-  (strategy       nil :type (or null discover-strategy)))
+  (strategy       nil :type discover-strategy))
 
 ;;;
 ;;; blossom-node command definitions

--- a/src/operations/scan.lisp
+++ b/src/operations/scan.lisp
@@ -70,7 +70,7 @@ Most of the slots are self-explanatory.  As an exception, ROOT-BUCKET aggregates
   (local-blossom  nil :type (or null address))
   (weight         nil :type real)
   (internal-roots nil :type list)
-  (repeat?        nil :type boolean))
+  (strategy       nil :type (or null discover-strategy)))
 
 (defstruct (message-soft-scan (:include message-scan))
   "The same as a SCAN, but it generates soft PINGs.")
@@ -202,7 +202,7 @@ When INTERNAL-ROOT-SET is supplied, discard HOLD recommendations which emanate f
   (petals         nil :type list)
   (weight         nil :type real)
   (internal-roots nil :type list)
-  (repeat?        nil :type boolean))
+  (strategy       nil :type (or null discover-strategy)))
 
 ;;;
 ;;; blossom-node command definitions
@@ -257,7 +257,7 @@ When INTERNAL-ROOT-SET is supplied, discard HOLD recommendations which emanate f
                                            (blossom-node-children node))))
          (internal-roots (or (message-scan-internal-roots scan-message)
                              (list local-root)))
-         (repeat? (slot-value scan-message 'repeat?)))
+         (strategy (slot-value scan-message 'strategy)))
     (log-entry :entry-type 'starting-scan
                :deweight weight)
     (push (make-data-frame-scan :local-root local-root
@@ -266,7 +266,7 @@ When INTERNAL-ROOT-SET is supplied, discard HOLD recommendations which emanate f
                                 :pong pong
                                 :soft? soft?
                                 :internal-roots internal-roots
-                                :repeat? repeat?)
+                                :strategy strategy)
           (process-data-stack node))
     ;; load (most of) script
     (process-continuation node
@@ -278,13 +278,13 @@ When INTERNAL-ROOT-SET is supplied, discard HOLD recommendations which emanate f
   "Request from the dryad responsible for this node a list of candidate node neighbors with which to coordinate for this node's next operation.  Defers the actual processing of that list to PROCESS-ADDRESSES."
   (unless (or (blossom-node-petals node)
               (not (blossom-node-positive? node)))
-    (with-slots (weight repeat?) (peek (process-data-stack node))
+    (with-slots (weight strategy) (peek (process-data-stack node))
       (sync-rpc (make-message-discover
                  :id (blossom-node-id node)
                  :address (process-public-address node)
                  ;; negated bc `weight' is negated above in `START-SCAN' let block
                  :internal-weight (- weight)
-                 :repeat? repeat?)
+                 :strategy strategy)
           (discovery-message (blossom-node-dryad node)
            :message-type message-discovery :message-unpacker identity
            :returned? returned?)
@@ -303,7 +303,7 @@ When INTERNAL-ROOT-SET is supplied, discard HOLD recommendations which emanate f
 
 (define-process-upkeep ((node blossom-node)) (FORWARD-SCAN addresses)
   "Sends a SCAN message to each of the children tabulated in ADDRESSES."
-  (with-slots (local-root local-blossom weight pong soft? internal-roots repeat?)
+  (with-slots (local-root local-blossom weight pong soft? internal-roots strategy)
       (peek (process-data-stack node))
     (unless (blossom-node-wilting node)
       (flet ((payload-constructor ()
@@ -314,14 +314,14 @@ When INTERNAL-ROOT-SET is supplied, discard HOLD recommendations which emanate f
                    :local-blossom local-blossom
                    :weight weight
                    :internal-roots internal-roots
-                   :repeat? repeat?))
+                   :strategy strategy))
                  (t
                   (make-message-scan
                    :local-root local-root
                    :local-blossom local-blossom
                    :weight weight
                    :internal-roots internal-roots
-                   :repeat? repeat?)))))
+                   :strategy strategy)))))
         (with-replies (replies
                        :returned? returned?
                        :message-type message-pong

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -61,7 +61,7 @@
    #:message-discover-address           ; ACCESSOR
    #:message-discover-id                ; ACCESSOR
    #:message-discover-internal-weight   ; ACCESSOR
-   #:message-discover-repeat?           ; ACCESSOR
+   #:message-discover-strategy          ; ACCESSOR
    #:message-discovery-channels-to-try  ; ACCESSOR
    #:message-discovery-future-distance  ; ACCESSOR
    #:message-sprout-address             ; ACCESSOR

--- a/src/supervisor.lisp
+++ b/src/supervisor.lisp
@@ -128,7 +128,13 @@ PONG: The PONG that this process received at its START."
       (with-replies (values-lists) (send-message-batch #'payload-constructor roots)
         (loop :for (parent pistil match-edge) :in values-lists
               :do (when (or parent pistil match-edge)
-                (setf (process-lockable-aborting? supervisor) t)))))))
+                    (log-entry :entry-type 'check-roots-aborting
+                               :roots roots
+                               :values-lists values-lists
+                               :parent parent
+                               :pistil pistil
+                               :match-edge match-edge)
+                    (setf (process-lockable-aborting? supervisor) t)))))))
 
 (define-process-upkeep ((supervisor supervisor)) (CHECK-PONG stale-pong)
   "Ensure that two locked trees still agree that this is a responsible weightless operation."

--- a/tests/node.lisp
+++ b/tests/node.lisp
@@ -332,11 +332,12 @@ Finally, all of the nodes constructed by this BLOSSOM-LET are stashed in the pla
                     target-node
                     (process-public-address target-node))))
 
-(defun supervisor (simulation &rest pong-initargs)
+(defun supervisor (simulation &rest pong-initargs &key (time 0) &allow-other-keys)
   "Helper constructor for a SUPERVISOR primed to run a bespoke PONG."
   (initialize-and-return
       ((supervisor (spawn-process 'anatevka::supervisor :debug? t)))
-    (simulation-add-event simulation (make-event :callback supervisor :time 0))
+    (simulation-add-event simulation (make-event :callback supervisor :time time))
+    (remf pong-initargs :time)
     (push (apply #'anatevka::make-message-pong
                  (append pong-initargs
                          (list :weight 0)))

--- a/tests/operations/multireweight.lisp
+++ b/tests/operations/multireweight.lisp
@@ -958,12 +958,9 @@ it declines to take action because C has priority.
             (is (tree-equalp original-tree target-tree))))))))
 
 ;;;
-;;; multi-cluster tests (internal pong is internal)
+;;; multi-cluster tests (internal pong rec edge is cluster-internal)
 ;;;
 
-;; NB: this test is in main as-is, and should fail after the changes
-;;     (post-changes one cluster should reweight by 2)
-;;     NVM these stay the same because the internal pong is internal
 (deftest test-supervisor-multireweight-simultaneous-rewind-halfway ()
   "Checks the transformation
 
@@ -1122,8 +1119,6 @@ The point of this is to show that simultaneous reweighting and rewinding during 
                   :children (list (vv-edge L K))))
             (is (tree-equalp original-tree target-tree))))))))
 
-;; NB: this test is in main as-is, and should fail after the changes
-;;     (post-changes one cluster should reweight by 1)
 (deftest test-supervisor-multireweight-simultaneous-rewind-non-integer ()
   "Checks the transformation
 
@@ -1286,10 +1281,9 @@ The point of this is to show that simultaneous reweighting and rewinding during 
             (is (tree-equalp original-tree target-tree))))))))
 
 ;;;
-;;; multi-cluster tests (internal-pong is external)
+;;; multi-cluster tests (internal-pong rec edge is cluster-external)
+;;;
 
-;; NB: this is a new test, and should fail after the changes
-;;     (post-changes one cluster should reweight by 1)
 (deftest test-supervisor-multireweight-2-clusters ()
   "Checks the transformation
 
@@ -1462,18 +1456,18 @@ d(B, D), d(J, L) = 2 and d(F, G) = 1
                   :children (list (vv-edge N M))))
             (is (tree-equalp original-tree target-tree))))))))
 
-;; NB: this is a new test, and should fail after the changes
-;;     (post-changes one left cluster and the right cluster should reweight by 1)
 (deftest test-supervisor-multireweight-3-clusters ()
-  "Checks that this configuration will yield all 0->1/2 and all 2->3/2 for the left two clusters (A,D) and (I,L), and all 0->3/2 and all 1->1/2 for the rightmost cluster (M,P)
+  "Checks that this configuration will result in the following:
+- the leftmost cluster (A,D) will multireweight by 1
+- the rightmost cluster (M,P) will multireweight by 1
 
- 0  2  0        0  2  0   0  2  0
- +  -  +        +  -  +   +  -  +
- A->B=>C        J<=K<-L   M->N=>O
+ 0  2  0        0  2  0  0  2  0
+ +  -  +        +  -  +  +  -  +
+ A->B=>C        J<=K<-L  M->N=>O
 
-    D->E=>F  G<=H<-I         P->Q=>R
-    +  -  +  +  -  +         +  -  +
-    0  2  0  0  2  0         0  2  0
+    D->E=>F  G<=H<-I        P->Q=>R
+    +  -  +  +  -  +        +  -  +
+    0  2  0  0  2  0        0  2  0
 
 d(B, D), d(H, J), d(N, P) = 2 and d(F, G), d(L, M) = 1
 "
@@ -1679,7 +1673,6 @@ d(B, D), d(H, J), d(N, P) = 2 and d(F, G), d(L, M) = 1
                   :match-edge (vv-edge R Q)
                   :parent (vv-edge R Q)))
             (is (tree-equalp original-tree target-tree))))))))
-
 
 (deftest test-supervisor-multireweight-4-clusters ()
   "Checks that this configuration will result in the following:

--- a/tests/operations/multireweight.lisp
+++ b/tests/operations/multireweight.lisp
@@ -702,325 +702,6 @@ The point of this is to show that simultaneous root-set aggregation in multirewe
                   :children (list (vv-edge F E))))
             (is (tree-equalp original-tree target-tree))))))))
 
-(deftest test-supervisor-multireweight-simultaneous-rewind-halfway ()
-  "Checks the transformation
-
- 0    2    0              0    2    0         1    1    1              1    1    1
- +    -    +              +    -    +         +    -    +              +    -    +
- A -> B => C              J <= K <- L         A -> B => C              J <= K <- L
-                                        -->
-      D -> E => F    G <= H <- I                   D -> E => F    G <= H <- I
-      +    -    +    +    -    +                   +    -    +    +    -    +
-      0    2    0    0    2    0                   1    1    1    1    1    1
-
-d(B, D), d(F, G), d(H, J)  = 2
-
-The point of this is to show that simultaneous reweighting and rewinding during multireweighting won't cause a negative-weight edge (all roots in the root-set are rewound) and for inter-root-set distances > 1 the algorithm will progress.
-"
-  (with-with ((with-courier ())
-              (with-simulation (simulation (*local-courier*)))
-              (with-address-dereferencing ()))
-    (let* ((dryad (spawn-process 'dryad :match-address (register)
-                                        :debug? t))
-           (dryad-address (process-public-address dryad)))
-      (blossom-let (original-tree :dryad dryad-address)
-          ((A :id (id 0 2)
-              :children (list (vv-edge A B))
-              :held-by-roots (list D)
-              :paused? T)
-           (B :id (id 2 2)
-              :children (list (vv-edge B C))
-              :internal-weight 2
-              :match-edge (vv-edge B C)
-              :parent (vv-edge B A)
-              :positive? nil)
-           (C :id (id 4 2)
-              :match-edge (vv-edge C B)
-              :parent (vv-edge C B))
-           (D :id (id 2 0)
-              :children (list (vv-edge D E))
-              :held-by-roots (list A))
-           (E :id (id 4 0)
-              :children (list (vv-edge E F))
-              :internal-weight 2
-              :match-edge (vv-edge E F)
-              :parent (vv-edge E D)
-              :positive? nil)
-           (F :id (id 6 0)
-              :match-edge (vv-edge F E)
-              :parent (vv-edge F E))
-           (G :id (id 8 0)
-              :match-edge (vv-edge G H)
-              :parent (vv-edge G H))
-           (H :id (id 10 0)
-              :children (list (vv-edge H G))
-              :internal-weight 2
-              :match-edge (vv-edge H G)
-              :parent (vv-edge H I)
-              :positive? nil)
-           (I :id (id 12 0)
-              :children (list (vv-edge I H))
-              :held-by-roots (list L)
-              :paused? T)
-           (J :id (id 10 2)
-              :match-edge (vv-edge J K)
-              :parent (vv-edge J K))
-           (K :id (id 12 2)
-              :children (list (vv-edge K J))
-              :internal-weight 2
-              :match-edge (vv-edge K J)
-              :parent (vv-edge K L)
-              :positive? nil)
-           (L :id (id 14 2)
-              :children (list (vv-edge L K))
-              :held-by-roots (list I)))
-
-        (let ((supervisor-left (supervisor simulation
-                                           :recommendation ':hold
-                                           :weight 0
-                                           :edges (list (vv-edge B D))
-                                           :source-root (process-public-address A)
-                                           :target-root (process-public-address D)
-                                           :source-id (slot-value B 'anatevka::id)
-                                           :root-bucket (list
-                                                         (process-public-address D))))
-              (supervisor-right (supervisor simulation
-                                           :recommendation ':hold
-                                           :weight 0
-                                           :edges (list (vv-edge I K))
-                                           :source-root (process-public-address I)
-                                           :target-root (process-public-address L)
-                                           :source-id (slot-value I 'anatevka::id)
-                                           :root-bucket (list (process-public-address L)))))
-          (simulate-add-tree simulation original-tree)
-
-          ;; fill the dryad and add it to the simulation
-          (dolist (node original-tree)
-          (let* ((id (slot-value node 'anatevka::id))
-                 (address (process-public-address node))
-                 (sprouted? (not (null (anatevka::blossom-node-match-edge node)))))
-            (setf (gethash address (anatevka::dryad-ids dryad))       id
-                  (gethash address (anatevka::dryad-sprouted? dryad)) sprouted?)))
-          (simulation-add-event simulation (make-event :callback dryad))
-
-          (simulate-until-dead simulation supervisor-left)
-          (simulate-until-dead simulation supervisor-right)
-          (blossom-let (target-tree :dryad dryad-address)
-              ((A :id (id 0 2)
-                  :internal-weight 1
-                  :children (list (vv-edge A B)))
-               (B :id (id 2 2)
-                  :children (list (vv-edge B C))
-                  :internal-weight 1
-                  :match-edge (vv-edge B C)
-                  :parent (vv-edge B A)
-                  :positive? nil)
-               (C :id (id 4 2)
-                  :internal-weight 1
-                  :match-edge (vv-edge C B)
-                  :parent (vv-edge C B))
-               (D :id (id 2 0)
-                  :internal-weight 1
-                  :children (list (vv-edge D E)))
-               (E :id (id 4 0)
-                  :children (list (vv-edge E F))
-                  :internal-weight 1
-                  :match-edge (vv-edge E F)
-                  :parent (vv-edge E D)
-                  :positive? nil)
-               (F :id (id 6 0)
-                  :internal-weight 1
-                  :match-edge (vv-edge F E)
-                  :parent (vv-edge F E))
-               (G :id (id 8 0)
-                  :internal-weight 1
-                  :match-edge (vv-edge G H)
-                  :parent (vv-edge G H))
-               (H :id (id 10 0)
-                  :children (list (vv-edge H G))
-                  :internal-weight 1
-                  :match-edge (vv-edge H G)
-                  :parent (vv-edge H I)
-                  :positive? nil)
-               (I :id (id 12 0)
-                  :internal-weight 1
-                  :children (list (vv-edge I H)))
-               (J :id (id 10 2)
-                  :internal-weight 1
-                  :match-edge (vv-edge J K)
-                  :parent (vv-edge J K))
-               (K :id (id 12 2)
-                  :children (list (vv-edge K J))
-                  :internal-weight 1
-                  :match-edge (vv-edge K J)
-                  :parent (vv-edge K L)
-                  :positive? nil)
-               (L :id (id 14 2)
-                  :internal-weight 1
-                  :children (list (vv-edge L K))))
-            (is (tree-equalp original-tree target-tree))))))))
-
-(deftest test-supervisor-multireweight-simultaneous-rewind-non-integer ()
-  "Checks the transformation
-
- 0    1    0              0    1    0        0.5  0.5  0.5            0.5  0.5  0.5
- +    -    +              +    -    +         +    -    +              +    -    +
- A -> B => C              J <= K <- L         A -> B => C              J <= K <- L
-                                        -->
-      D -> E => F    G <= H <- I                   D -> E => F    G <= H <- I
-      +    -    +    +    -    +                   +    -    +    +    -    +
-      0    1    0    0    1    0                  0.5  0.5  0.5  0.5  0.5  0.5
-
-d(B, D), d(F, G), d(H, J)  = 1
-
-The point of this is to show that simultaneous reweighting and rewinding during multireweighting will still ensure progress even if the inter-root-set distance is 1 (or smaller) by using non-integer rewinds.
-"
-  (with-with ((with-courier ())
-              (with-simulation (simulation (*local-courier*)))
-              (with-address-dereferencing ()))
-    (let* ((dryad (spawn-process 'dryad :match-address (register)
-                                        :debug? t))
-           (dryad-address (process-public-address dryad)))
-      (blossom-let (original-tree :dryad dryad-address)
-          ((A :id (id 0 1)
-              :children (list (vv-edge A B))
-              :held-by-roots (list D)
-              :paused? T)
-           (B :id (id 1 1)
-              :children (list (vv-edge B C))
-              :internal-weight 1
-              :match-edge (vv-edge B C)
-              :parent (vv-edge B A)
-              :positive? nil)
-           (C :id (id 2 1)
-              :match-edge (vv-edge C B)
-              :parent (vv-edge C B))
-           (D :id (id 1 0)
-              :children (list (vv-edge D E))
-              :held-by-roots (list A))
-           (E :id (id 2 0)
-              :children (list (vv-edge E F))
-              :internal-weight 1
-              :match-edge (vv-edge E F)
-              :parent (vv-edge E D)
-              :positive? nil)
-           (F :id (id 3 0)
-              :match-edge (vv-edge F E)
-              :parent (vv-edge F E))
-           (G :id (id 4 0)
-              :match-edge (vv-edge G H)
-              :parent (vv-edge G H))
-           (H :id (id 5 0)
-              :children (list (vv-edge H G))
-              :internal-weight 1
-              :match-edge (vv-edge H G)
-              :parent (vv-edge H I)
-              :positive? nil)
-           (I :id (id 6 0)
-              :children (list (vv-edge I H))
-              :held-by-roots (list L)
-              :paused? T)
-           (J :id (id 5 1)
-              :match-edge (vv-edge J K)
-              :parent (vv-edge J K))
-           (K :id (id 6 1)
-              :children (list (vv-edge K J))
-              :internal-weight 1
-              :match-edge (vv-edge K J)
-              :parent (vv-edge K L)
-              :positive? nil)
-           (L :id (id 7 1)
-              :children (list (vv-edge L K))
-              :held-by-roots (list I)))
-
-        (let ((supervisor-left (supervisor simulation
-                                           :recommendation ':hold
-                                           :weight 0
-                                           :edges (list (vv-edge B D))
-                                           :source-root (process-public-address A)
-                                           :target-root (process-public-address D)
-                                           :source-id (slot-value B 'anatevka::id)
-                                           :root-bucket (list
-                                                         (process-public-address D))))
-              (supervisor-right (supervisor simulation
-                                           :recommendation ':hold
-                                           :weight 0
-                                           :edges (list (vv-edge I K))
-                                           :source-root (process-public-address I)
-                                           :target-root (process-public-address L)
-                                           :source-id (slot-value I 'anatevka::id)
-                                           :root-bucket (list (process-public-address L)))))
-          (simulate-add-tree simulation original-tree)
-
-          ;; fill the dryad and add it to the simulation
-          (dolist (node original-tree)
-          (let* ((id (slot-value node 'anatevka::id))
-                 (address (process-public-address node))
-                 (sprouted? (not (null (anatevka::blossom-node-match-edge node)))))
-            (setf (gethash address (anatevka::dryad-ids dryad))       id
-                  (gethash address (anatevka::dryad-sprouted? dryad)) sprouted?)))
-          (simulation-add-event simulation (make-event :callback dryad))
-
-          (simulate-until-dead simulation supervisor-left)
-          (simulate-until-dead simulation supervisor-right)
-          (blossom-let (target-tree :dryad dryad-address)
-              ((A :id (id 0 1)
-                  :internal-weight 0.5
-                  :children (list (vv-edge A B)))
-               (B :id (id 1 1)
-                  :internal-weight 0.5
-                  :children (list (vv-edge B C))
-                  :match-edge (vv-edge B C)
-                  :parent (vv-edge B A)
-                  :positive? nil)
-               (C :id (id 2 1)
-                  :internal-weight 0.5
-                  :match-edge (vv-edge C B)
-                  :parent (vv-edge C B))
-               (D :id (id 1 0)
-                  :internal-weight 0.5
-                  :children (list (vv-edge D E)))
-               (E :id (id 2 0)
-                  :internal-weight 0.5
-                  :children (list (vv-edge E F))
-                  :match-edge (vv-edge E F)
-                  :parent (vv-edge E D)
-                  :positive? nil)
-               (F :id (id 3 0)
-                  :internal-weight 0.5
-                  :match-edge (vv-edge F E)
-                  :parent (vv-edge F E))
-               (G :id (id 4 0)
-                  :internal-weight 0.5
-                  :match-edge (vv-edge G H)
-                  :parent (vv-edge G H))
-               (H :id (id 5 0)
-                  :internal-weight 0.5
-                  :children (list (vv-edge H G))
-                  :match-edge (vv-edge H G)
-                  :parent (vv-edge H I)
-                  :positive? nil)
-               (I :id (id 6 0)
-                  :internal-weight 0.5
-                  :children (list (vv-edge I H)))
-               (J :id (id 5 1)
-                  :internal-weight 0.5
-                  :match-edge (vv-edge J K)
-                  :parent (vv-edge J K))
-               (K :id (id 6 1)
-                  :internal-weight 0.5
-                  :children (list (vv-edge K J))
-                  :match-edge (vv-edge K J)
-                  :parent (vv-edge K L)
-                  :positive? nil)
-               (L :id (id 7 1)
-                  :internal-weight 0.5
-                  :children (list (vv-edge L K)))
-               (BOUNDARY :id (id -1 0)
-                         :match-edge (vv-edge B A)
-                         :parent (vv-edge B A)))
-            (is (tree-equalp original-tree target-tree))))))))
-
 (deftest test-supervisor-multireweight-simultaneous-staircase ()
   "Checks the transformation
 
@@ -1274,4 +955,1005 @@ it declines to take action because C has priority.
                (FF :id (id 10 0)
                    :children (list (vv-edge FF EE))
                    :held-by-roots (list CC)))
+            (is (tree-equalp original-tree target-tree))))))))
+
+;;;
+;;; multi-cluster tests
+;;;
+
+;; NB: this test is in main as-is, and should fail after the changes
+;;     (post-changes one cluster should reweight by 2)
+(deftest test-supervisor-multireweight-simultaneous-rewind-halfway ()
+  "Checks the transformation
+
+ 0    2    0              0    2    0         1    1    1              1    1    1
+ +    -    +              +    -    +         +    -    +              +    -    +
+ A -> B => C              J <= K <- L         A -> B => C              J <= K <- L
+                                        -->
+      D -> E => F    G <= H <- I                   D -> E => F    G <= H <- I
+      +    -    +    +    -    +                   +    -    +    +    -    +
+      0    2    0    0    2    0                   1    1    1    1    1    1
+
+d(B, D), d(F, G), d(H, J)  = 2
+
+The point of this is to show that simultaneous reweighting and rewinding during multireweighting won't cause a negative-weight edge (all roots in the root-set are rewound) and for inter-root-set distances > 1 the algorithm will progress.
+"
+  (with-with ((with-courier ())
+              (with-simulation (simulation (*local-courier*)))
+              (with-address-dereferencing ()))
+    (let* ((dryad (spawn-process 'dryad :match-address (register)
+                                        :debug? t))
+           (dryad-address (process-public-address dryad)))
+      (blossom-let (original-tree :dryad dryad-address)
+          ((A :id (id 0 2)
+              :children (list (vv-edge A B))
+              :held-by-roots (list D)
+              :paused? T)
+           (B :id (id 2 2)
+              :children (list (vv-edge B C))
+              :internal-weight 2
+              :match-edge (vv-edge B C)
+              :parent (vv-edge B A)
+              :positive? nil)
+           (C :id (id 4 2)
+              :match-edge (vv-edge C B)
+              :parent (vv-edge C B))
+           (D :id (id 2 0)
+              :children (list (vv-edge D E))
+              :held-by-roots (list A))
+           (E :id (id 4 0)
+              :children (list (vv-edge E F))
+              :internal-weight 2
+              :match-edge (vv-edge E F)
+              :parent (vv-edge E D)
+              :positive? nil)
+           (F :id (id 6 0)
+              :match-edge (vv-edge F E)
+              :parent (vv-edge F E))
+           (G :id (id 8 0)
+              :match-edge (vv-edge G H)
+              :parent (vv-edge G H))
+           (H :id (id 10 0)
+              :children (list (vv-edge H G))
+              :internal-weight 2
+              :match-edge (vv-edge H G)
+              :parent (vv-edge H I)
+              :positive? nil)
+           (I :id (id 12 0)
+              :children (list (vv-edge I H))
+              :held-by-roots (list L)
+              :paused? T)
+           (J :id (id 10 2)
+              :match-edge (vv-edge J K)
+              :parent (vv-edge J K))
+           (K :id (id 12 2)
+              :children (list (vv-edge K J))
+              :internal-weight 2
+              :match-edge (vv-edge K J)
+              :parent (vv-edge K L)
+              :positive? nil)
+           (L :id (id 14 2)
+              :children (list (vv-edge L K))
+              :held-by-roots (list I)))
+
+        (let ((supervisor-left (supervisor simulation
+                                           :recommendation ':hold
+                                           :weight 0
+                                           :edges (list (vv-edge B D))
+                                           :source-root (process-public-address A)
+                                           :target-root (process-public-address D)
+                                           :source-id (slot-value B 'anatevka::id)
+                                           :root-bucket (list
+                                                         (process-public-address D))))
+              (supervisor-right (supervisor simulation
+                                           :recommendation ':hold
+                                           :weight 0
+                                           :edges (list (vv-edge I K))
+                                           :source-root (process-public-address I)
+                                           :target-root (process-public-address L)
+                                           :source-id (slot-value I 'anatevka::id)
+                                           :root-bucket (list (process-public-address L)))))
+          (simulate-add-tree simulation original-tree)
+
+          ;; fill the dryad and add it to the simulation
+          (dolist (node original-tree)
+          (let* ((id (slot-value node 'anatevka::id))
+                 (address (process-public-address node))
+                 (sprouted? (not (null (anatevka::blossom-node-match-edge node)))))
+            (setf (gethash address (anatevka::dryad-ids dryad))       id
+                  (gethash address (anatevka::dryad-sprouted? dryad)) sprouted?)))
+          (simulation-add-event simulation (make-event :callback dryad))
+
+          (simulate-until-dead simulation supervisor-left)
+          (simulate-until-dead simulation supervisor-right)
+          (blossom-let (target-tree :dryad dryad-address)
+              ((A :id (id 0 2)
+                  :internal-weight 1
+                  :children (list (vv-edge A B)))
+               (B :id (id 2 2)
+                  :children (list (vv-edge B C))
+                  :internal-weight 1
+                  :match-edge (vv-edge B C)
+                  :parent (vv-edge B A)
+                  :positive? nil)
+               (C :id (id 4 2)
+                  :internal-weight 1
+                  :match-edge (vv-edge C B)
+                  :parent (vv-edge C B))
+               (D :id (id 2 0)
+                  :internal-weight 1
+                  :children (list (vv-edge D E)))
+               (E :id (id 4 0)
+                  :children (list (vv-edge E F))
+                  :internal-weight 1
+                  :match-edge (vv-edge E F)
+                  :parent (vv-edge E D)
+                  :positive? nil)
+               (F :id (id 6 0)
+                  :internal-weight 1
+                  :match-edge (vv-edge F E)
+                  :parent (vv-edge F E))
+               (G :id (id 8 0)
+                  :internal-weight 1
+                  :match-edge (vv-edge G H)
+                  :parent (vv-edge G H))
+               (H :id (id 10 0)
+                  :children (list (vv-edge H G))
+                  :internal-weight 1
+                  :match-edge (vv-edge H G)
+                  :parent (vv-edge H I)
+                  :positive? nil)
+               (I :id (id 12 0)
+                  :internal-weight 1
+                  :children (list (vv-edge I H)))
+               (J :id (id 10 2)
+                  :internal-weight 1
+                  :match-edge (vv-edge J K)
+                  :parent (vv-edge J K))
+               (K :id (id 12 2)
+                  :children (list (vv-edge K J))
+                  :internal-weight 1
+                  :match-edge (vv-edge K J)
+                  :parent (vv-edge K L)
+                  :positive? nil)
+               (L :id (id 14 2)
+                  :internal-weight 1
+                  :children (list (vv-edge L K))))
+            (is (tree-equalp original-tree target-tree))))))))
+
+;; NB: this test is in main as-is, and should fail after the changes
+;;     (post-changes one cluster should reweight by 1)
+(deftest test-supervisor-multireweight-simultaneous-rewind-non-integer ()
+  "Checks the transformation
+
+ 0    1    0              0    1    0        0.5  0.5  0.5            0.5  0.5  0.5
+ +    -    +              +    -    +         +    -    +              +    -    +
+ A -> B => C              J <= K <- L         A -> B => C              J <= K <- L
+                                        -->
+      D -> E => F    G <= H <- I                   D -> E => F    G <= H <- I
+      +    -    +    +    -    +                   +    -    +    +    -    +
+      0    1    0    0    1    0                  0.5  0.5  0.5  0.5  0.5  0.5
+
+d(B, D), d(F, G), d(H, J)  = 1
+
+The point of this is to show that simultaneous reweighting and rewinding during multireweighting will still ensure progress even if the inter-root-set distance is 1 (or smaller) by using non-integer rewinds.
+"
+  (with-with ((with-courier ())
+              (with-simulation (simulation (*local-courier*)))
+              (with-address-dereferencing ()))
+    (let* ((dryad (spawn-process 'dryad :match-address (register)
+                                        :debug? t))
+           (dryad-address (process-public-address dryad)))
+      (blossom-let (original-tree :dryad dryad-address)
+          ((A :id (id 0 1)
+              :children (list (vv-edge A B))
+              :held-by-roots (list D)
+              :paused? T)
+           (B :id (id 1 1)
+              :children (list (vv-edge B C))
+              :internal-weight 1
+              :match-edge (vv-edge B C)
+              :parent (vv-edge B A)
+              :positive? nil)
+           (C :id (id 2 1)
+              :match-edge (vv-edge C B)
+              :parent (vv-edge C B))
+           (D :id (id 1 0)
+              :children (list (vv-edge D E))
+              :held-by-roots (list A))
+           (E :id (id 2 0)
+              :children (list (vv-edge E F))
+              :internal-weight 1
+              :match-edge (vv-edge E F)
+              :parent (vv-edge E D)
+              :positive? nil)
+           (F :id (id 3 0)
+              :match-edge (vv-edge F E)
+              :parent (vv-edge F E))
+           (G :id (id 4 0)
+              :match-edge (vv-edge G H)
+              :parent (vv-edge G H))
+           (H :id (id 5 0)
+              :children (list (vv-edge H G))
+              :internal-weight 1
+              :match-edge (vv-edge H G)
+              :parent (vv-edge H I)
+              :positive? nil)
+           (I :id (id 6 0)
+              :children (list (vv-edge I H))
+              :held-by-roots (list L)
+              :paused? T)
+           (J :id (id 5 1)
+              :match-edge (vv-edge J K)
+              :parent (vv-edge J K))
+           (K :id (id 6 1)
+              :children (list (vv-edge K J))
+              :internal-weight 1
+              :match-edge (vv-edge K J)
+              :parent (vv-edge K L)
+              :positive? nil)
+           (L :id (id 7 1)
+              :children (list (vv-edge L K))
+              :held-by-roots (list I)))
+
+        (let ((supervisor-left (supervisor simulation
+                                           :recommendation ':hold
+                                           :weight 0
+                                           :edges (list (vv-edge B D))
+                                           :source-root (process-public-address A)
+                                           :target-root (process-public-address D)
+                                           :source-id (slot-value B 'anatevka::id)
+                                           :root-bucket (list
+                                                         (process-public-address D))))
+              (supervisor-right (supervisor simulation
+                                           :recommendation ':hold
+                                           :weight 0
+                                           :edges (list (vv-edge I K))
+                                           :source-root (process-public-address I)
+                                           :target-root (process-public-address L)
+                                           :source-id (slot-value I 'anatevka::id)
+                                           :root-bucket (list (process-public-address L)))))
+          (simulate-add-tree simulation original-tree)
+
+          ;; fill the dryad and add it to the simulation
+          (dolist (node original-tree)
+          (let* ((id (slot-value node 'anatevka::id))
+                 (address (process-public-address node))
+                 (sprouted? (not (null (anatevka::blossom-node-match-edge node)))))
+            (setf (gethash address (anatevka::dryad-ids dryad))       id
+                  (gethash address (anatevka::dryad-sprouted? dryad)) sprouted?)))
+          (simulation-add-event simulation (make-event :callback dryad))
+
+          (simulate-until-dead simulation supervisor-left)
+          (simulate-until-dead simulation supervisor-right)
+          (blossom-let (target-tree :dryad dryad-address)
+              ((A :id (id 0 1)
+                  :internal-weight 0.5
+                  :children (list (vv-edge A B)))
+               (B :id (id 1 1)
+                  :internal-weight 0.5
+                  :children (list (vv-edge B C))
+                  :match-edge (vv-edge B C)
+                  :parent (vv-edge B A)
+                  :positive? nil)
+               (C :id (id 2 1)
+                  :internal-weight 0.5
+                  :match-edge (vv-edge C B)
+                  :parent (vv-edge C B))
+               (D :id (id 1 0)
+                  :internal-weight 0.5
+                  :children (list (vv-edge D E)))
+               (E :id (id 2 0)
+                  :internal-weight 0.5
+                  :children (list (vv-edge E F))
+                  :match-edge (vv-edge E F)
+                  :parent (vv-edge E D)
+                  :positive? nil)
+               (F :id (id 3 0)
+                  :internal-weight 0.5
+                  :match-edge (vv-edge F E)
+                  :parent (vv-edge F E))
+               (G :id (id 4 0)
+                  :internal-weight 0.5
+                  :match-edge (vv-edge G H)
+                  :parent (vv-edge G H))
+               (H :id (id 5 0)
+                  :internal-weight 0.5
+                  :children (list (vv-edge H G))
+                  :match-edge (vv-edge H G)
+                  :parent (vv-edge H I)
+                  :positive? nil)
+               (I :id (id 6 0)
+                  :internal-weight 0.5
+                  :children (list (vv-edge I H)))
+               (J :id (id 5 1)
+                  :internal-weight 0.5
+                  :match-edge (vv-edge J K)
+                  :parent (vv-edge J K))
+               (K :id (id 6 1)
+                  :internal-weight 0.5
+                  :children (list (vv-edge K J))
+                  :match-edge (vv-edge K J)
+                  :parent (vv-edge K L)
+                  :positive? nil)
+               (L :id (id 7 1)
+                  :internal-weight 0.5
+                  :children (list (vv-edge L K)))
+               (BOUNDARY :id (id -1 0)
+                         :match-edge (vv-edge B A)
+                         :parent (vv-edge B A)))
+            (is (tree-equalp original-tree target-tree))))))))
+
+;; NB: this is a new test, and should fail after the changes
+;;     (post-changes one cluster should reweight by 1)
+(deftest test-supervisor-multireweight-2-clusters ()
+  "Checks the transformation
+
+                                                       3  5  3
+                                                       /  /  /
+ 0  2  0              0  2  0     0  0  0              4  4  4
+ +  -  +              +  -  +     +  -  +              +  -  +
+ A->B=>C              L<=M<-N     A->B=>C              L<=M<-N
+                              -->
+    D->E=>F  G<=H<-I<=J<-K           D->E=>F  G<=H<-I<=J<-K
+    +  -  +  +  -  +  -  +           +  -  +  +  -  +  -  +
+    0  2  0  0  2  0  2  0           0  0  0  3  5  3  5  3
+                                              /  /  /  /  /
+                                              4  4  4  4  4
+
+d(B, D), d(J, L) = 2 and d(F, G) = 1
+"
+  (with-with ((with-courier ())
+              (with-simulation (simulation (*local-courier*)))
+              (with-address-dereferencing ()))
+    (let* ((dryad (spawn-process 'dryad :match-address (register)
+                                        :debug? t))
+           (dryad-address (process-public-address dryad)))
+      (blossom-let (original-tree :dryad dryad-address)
+          ((A :id (id 0 2)
+              :children (list (vv-edge A B))
+              :held-by-roots (list D)
+              :paused? T)
+           (B :id (id 2 2)
+              :children (list (vv-edge B C))
+              :internal-weight 2
+              :match-edge (vv-edge B C)
+              :parent (vv-edge B A)
+              :positive? nil)
+           (C :id (id 4 2)
+              :match-edge (vv-edge C B)
+              :parent (vv-edge C B))
+           (D :id (id 2 0)
+              :children (list (vv-edge D E))
+              :held-by-roots (list A))
+           (E :id (id 4 0)
+              :children (list (vv-edge E F))
+              :internal-weight 2
+              :match-edge (vv-edge E F)
+              :parent (vv-edge E D)
+              :positive? nil)
+           (F :id (id 6 0)
+              :match-edge (vv-edge F E)
+              :parent (vv-edge F E))
+           (G :id (id 7 0)
+              :match-edge (vv-edge G H)
+              :parent (vv-edge G H))
+           (H :id (id 9 0)
+              :children (list (vv-edge H G))
+              :internal-weight 2
+              :match-edge (vv-edge H G)
+              :parent (vv-edge H I)
+              :positive? nil)
+           (I :id (id 11 0)
+              :children (list (vv-edge I H))
+              :match-edge (vv-edge I J)
+              :parent (vv-edge I J))
+           (J :id (id 13 0)
+              :internal-weight 2
+              :children (list (vv-edge J I))
+              :match-edge (vv-edge J I)
+              :parent (vv-edge J K)
+              :positive? nil)
+           (K :id (id 15 0)
+              :children (list (vv-edge K J))
+              :held-by-roots (list N)
+              :paused? T)
+           (L :id (id 13 2)
+              :match-edge (vv-edge L M)
+              :parent (vv-edge L M))
+           (M :id (id 15 2)
+              :children (list (vv-edge M L))
+              :internal-weight 2
+              :match-edge (vv-edge M L)
+              :parent (vv-edge M N)
+              :positive? nil)
+           (N :id (id 17 2)
+              :children (list (vv-edge N M))
+              :held-by-roots (list K)))
+        (let ((supervisor-left (supervisor simulation :time 1/2
+                                           :recommendation ':hold
+                                           :weight 0
+                                           :edges (list (vv-edge B D))
+                                           :source-root (process-public-address A)
+                                           :target-root (process-public-address D)
+                                           :source-id (slot-value B 'anatevka::id)
+                                           :root-bucket (list
+                                                         (process-public-address D))))
+              (supervisor-right (supervisor simulation :time 0
+                                           :recommendation ':hold
+                                           :weight 0
+                                           :edges (list (vv-edge J L))
+                                           :source-root (process-public-address K)
+                                           :target-root (process-public-address N)
+                                           :source-id (slot-value K 'anatevka::id)
+                                           :root-bucket (list (process-public-address N)))))
+          (simulate-add-tree simulation original-tree)
+
+          ;; fill the dryad and add it to the simulation
+          (dolist (node original-tree)
+          (let* ((id (slot-value node 'anatevka::id))
+                 (address (process-public-address node))
+                 (sprouted? (not (null (anatevka::blossom-node-match-edge node)))))
+            (setf (gethash address (anatevka::dryad-ids dryad))       id
+                  (gethash address (anatevka::dryad-sprouted? dryad)) sprouted?)))
+          (simulation-add-event simulation (make-event :callback dryad))
+
+          (simulate-until-dead simulation supervisor-left)
+          (simulate-until-dead simulation supervisor-right)
+          (blossom-let (target-tree :dryad dryad-address)
+              ((A :id (id 0 2)
+                  :children (list (vv-edge A B)))
+               (B :id (id 2 2)
+                  :children (list (vv-edge B C))
+                  :internal-weight 2
+                  :match-edge (vv-edge B C)
+                  :parent (vv-edge B A)
+                  :positive? nil)
+               (C :id (id 4 2)
+                  :match-edge (vv-edge C B)
+                  :parent (vv-edge C B))
+               (D :id (id 2 0)
+                  :children (list (vv-edge D E)))
+               (E :id (id 4 0)
+                  :children (list (vv-edge E F))
+                  :internal-weight 2
+                  :match-edge (vv-edge E F)
+                  :parent (vv-edge E D)
+                  :positive? nil)
+               (F :id (id 6 0)
+                  :match-edge (vv-edge F E)
+                  :parent (vv-edge F E))
+               (G :id (id 7 0)
+                  :internal-weight 3/4
+                  :match-edge (vv-edge G H)
+                  :parent (vv-edge G H))
+               (H :id (id 9 0)
+                  :children (list (vv-edge H G))
+                  :internal-weight 5/4
+                  :match-edge (vv-edge H G)
+                  :parent (vv-edge H I)
+                  :positive? nil)
+               (I :id (id 11 0)
+                  :internal-weight 3/4
+                  :children (list (vv-edge I H))
+                  :match-edge (vv-edge I J)
+                  :parent (vv-edge I J))
+               (J :id (id 13 0)
+                  :internal-weight 5/4
+                  :children (list (vv-edge J I))
+                  :match-edge (vv-edge J I)
+                  :parent (vv-edge J K)
+                  :positive? nil)
+               (K :id (id 15 0)
+                  :internal-weight 3/4
+                  :children (list (vv-edge K J)))
+               (L :id (id 13 2)
+                  :internal-weight 3/4
+                  :match-edge (vv-edge L M)
+                  :parent (vv-edge L M))
+               (M :id (id 15 2)
+                  :children (list (vv-edge M L))
+                  :internal-weight 5/4
+                  :match-edge (vv-edge M L)
+                  :parent (vv-edge M N)
+                  :positive? nil)
+               (N :id (id 17 2)
+                  :internal-weight 3/4
+                  :children (list (vv-edge N M))))
+            (is (tree-equalp original-tree target-tree))))))))
+
+;; NB: this is a new test, and should fail after the changes
+;;     (post-changes one left cluster and the right cluster should reweight by 1)
+(deftest test-supervisor-multireweight-3-clusters ()
+  "Checks that this configuration will yield all 0->1/2 and all 2->3/2 for the left two clusters (A,D) and (I,L), and all 0->3/2 and all 1->1/2 for the rightmost cluster (M,P)
+
+ 0  2  0        0  2  0   0  2  0
+ +  -  +        +  -  +   +  -  +
+ A->B=>C        J<=K<-L   M->N=>O
+
+    D->E=>F  G<=H<-I         P->Q=>R
+    +  -  +  +  -  +         +  -  +
+    0  2  0  0  2  0         0  2  0
+
+d(B, D), d(H, J), d(N, P) = 2 and d(F, G) = 1 and d(L, M) = 2
+"
+  (with-with ((with-courier ())
+              (with-simulation (simulation (*local-courier*)))
+              (with-address-dereferencing ()))
+    (let* ((dryad (spawn-process 'dryad :match-address (register)
+                                        :debug? t))
+           (dryad-address (process-public-address dryad)))
+      (blossom-let (original-tree :dryad dryad-address)
+          ((A :id (id 0 2)
+              :children (list (vv-edge A B))
+              :held-by-roots (list D)
+              :paused? T)
+           (B :id (id 2 2)
+              :children (list (vv-edge B C))
+              :internal-weight 2
+              :match-edge (vv-edge B C)
+              :parent (vv-edge B A)
+              :positive? nil)
+           (C :id (id 4 2)
+              :match-edge (vv-edge C B)
+              :parent (vv-edge C B))
+           (D :id (id 2 0)
+              :children (list (vv-edge D E))
+              :held-by-roots (list A))
+           (E :id (id 4 0)
+              :children (list (vv-edge E F))
+              :internal-weight 2
+              :match-edge (vv-edge E F)
+              :parent (vv-edge E D)
+              :positive? nil)
+           (F :id (id 6 0)
+              :match-edge (vv-edge F E)
+              :parent (vv-edge F E))
+           (G :id (id 7 0)
+              :match-edge (vv-edge G H)
+              :parent (vv-edge G H))
+           (H :id (id 9 0)
+              :children (list (vv-edge H G))
+              :internal-weight 2
+              :match-edge (vv-edge H G)
+              :parent (vv-edge H I)
+              :positive? nil)
+           (I :id (id 11 0)
+              :children (list (vv-edge I H))
+              :held-by-roots (list L)
+              :paused? T)
+           (J :id (id 9 2)
+              :match-edge (vv-edge J K)
+              :parent (vv-edge J K))
+           (K :id (id 11 2)
+              :children (list (vv-edge K J))
+              :internal-weight 2
+              :match-edge (vv-edge K J)
+              :parent (vv-edge K L)
+              :positive? nil)
+           (L :id (id 13 2)
+              :children (list (vv-edge L K))
+              :held-by-roots (list I))
+           (M :id (id 15 2)
+              :children (list (vv-edge M N))
+              :held-by-roots (list P)
+              :paused? T)
+           (N :id (id 17 2)
+              :children (list (vv-edge N O))
+              :internal-weight 2
+              :match-edge (vv-edge N O)
+              :parent (vv-edge N M)
+              :positive? nil)
+           (O :id (id 19 2)
+              :match-edge (vv-edge O N)
+              :parent (vv-edge O N))
+           (P :id (id 17 0)
+              :children (list (vv-edge P Q))
+              :held-by-roots (list M))
+           (Q :id (id 19 0)
+              :children (list (vv-edge Q R))
+              :internal-weight 2
+              :match-edge (vv-edge Q R)
+              :parent (vv-edge Q P)
+              :positive? nil)
+           (R :id (id 21 0)
+              :match-edge (vv-edge R Q)
+              :parent (vv-edge R Q)))
+        (let ((supervisor-A (supervisor simulation
+                                        :recommendation ':hold
+                                        :weight 0
+                                        :edges (list (vv-edge B D))
+                                        :source-root (process-public-address A)
+                                        :target-root (process-public-address D)
+                                        :source-id (slot-value B 'anatevka::id)
+                                        :root-bucket (list
+                                                      (process-public-address D))))
+              (supervisor-I (supervisor simulation
+                                        :recommendation ':hold
+                                        :weight 0
+                                        :edges (list (vv-edge I K))
+                                        :source-root (process-public-address I)
+                                        :target-root (process-public-address L)
+                                        :source-id (slot-value I 'anatevka::id)
+                                        :root-bucket (list (process-public-address L))))
+              (supervisor-M (supervisor simulation
+                                        :recommendation ':hold
+                                        :weight 0
+                                        :edges (list (vv-edge N P))
+                                        :source-root (process-public-address M)
+                                        :target-root (process-public-address P)
+                                        :source-id (slot-value N 'anatevka::id)
+                                        :root-bucket (list
+                                                      (process-public-address P)))))
+          (simulate-add-tree simulation original-tree)
+
+          ;; fill the dryad and add it to the simulation
+          (dolist (node original-tree)
+            (let* ((id (slot-value node 'anatevka::id))
+                   (address (process-public-address node))
+                   (sprouted? (not (null (anatevka::blossom-node-match-edge node)))))
+              (setf (gethash address (anatevka::dryad-ids dryad))       id
+                    (gethash address (anatevka::dryad-sprouted? dryad)) sprouted?)))
+          (simulation-add-event simulation (make-event :callback dryad))
+
+          (simulate-until-dead simulation supervisor-A)
+          (simulate-until-dead simulation supervisor-I)
+          (simulate-until-dead simulation supervisor-M)
+          (blossom-let (target-tree :dryad dryad-address)
+              ((A :id (id 0 2)
+                  :internal-weight 1/2
+                  :children (list (vv-edge A B)))
+               (B :id (id 2 2)
+                  :children (list (vv-edge B C))
+                  :internal-weight 3/2
+                  :match-edge (vv-edge B C)
+                  :parent (vv-edge B A)
+                  :positive? nil)
+               (C :id (id 4 2)
+                  :internal-weight 1/2
+                  :match-edge (vv-edge C B)
+                  :parent (vv-edge C B))
+               (D :id (id 2 0)
+                  :internal-weight 1/2
+                  :children (list (vv-edge D E)))
+               (E :id (id 4 0)
+                  :children (list (vv-edge E F))
+                  :internal-weight 3/2
+                  :match-edge (vv-edge E F)
+                  :parent (vv-edge E D)
+                  :positive? nil)
+               (F :id (id 6 0)
+                  :internal-weight 1/2
+                  :match-edge (vv-edge F E)
+                  :parent (vv-edge F E))
+               (G :id (id 7 0)
+                  :internal-weight 1/2
+                  :match-edge (vv-edge G H)
+                  :parent (vv-edge G H))
+               (H :id (id 9 0)
+                  :children (list (vv-edge H G))
+                  :internal-weight 3/2
+                  :match-edge (vv-edge H G)
+                  :parent (vv-edge H I)
+                  :positive? nil)
+               (I :id (id 11 0)
+                  :internal-weight 1/2
+                  :children (list (vv-edge I H)))
+               (J :id (id 9 2)
+                  :internal-weight 1/2
+                  :match-edge (vv-edge J K)
+                  :parent (vv-edge J K))
+               (K :id (id 11 2)
+                  :children (list (vv-edge K J))
+                  :internal-weight 3/2
+                  :match-edge (vv-edge K J)
+                  :parent (vv-edge K L)
+                  :positive? nil)
+               (L :id (id 13 2)
+                  :internal-weight 1/2
+                  :children (list (vv-edge L K)))
+               (M :id (id 15 2)
+                  :internal-weight 3/2
+                  :children (list (vv-edge M N)))
+               (N :id (id 17 2)
+                  :children (list (vv-edge N O))
+                  :internal-weight 1/2
+                  :match-edge (vv-edge N O)
+                  :parent (vv-edge N M)
+                  :positive? nil)
+               (O :id (id 19 2)
+                  :internal-weight 3/2
+                  :match-edge (vv-edge O N)
+                  :parent (vv-edge O N))
+               (P :id (id 17 0)
+                  :internal-weight 3/2
+                  :children (list (vv-edge P Q)))
+               (Q :id (id 19 0)
+                  :children (list (vv-edge Q R))
+                  :internal-weight 1/2
+                  :match-edge (vv-edge Q R)
+                  :parent (vv-edge Q P)
+                  :positive? nil)
+               (R :id (id 21 0)
+                  :internal-weight 3/2
+                  :match-edge (vv-edge R Q)
+                  :parent (vv-edge R Q)))
+            (is (tree-equalp original-tree target-tree))))))))
+
+;; NB: this is a new test, and should fail after the changes
+;;     (post-changes one left cluster and one right cluster should reweight by 1)
+(deftest test-supervisor-multireweight-4-clusters ()
+  "Checks that this configuration will yield all 0->1/2 and all 2->3/2
+
+ 0  2  0        0  2  0   0  2  0        0  2  0
+ +  -  +        +  -  +   +  -  +        +  -  +
+ A->B=>C        J<=K<-L   M->N=>O        W<=X<-Y
+
+    D->E=>F  G<=H<-I         P->Q=>R  S<=U<-V
+    +  -  +  +  -  +         +  -  +  +  -  +
+    0  2  0  0  2  0         0  2  0  0  2  0
+
+d(B, D), d(H, J), d(N, P), d(U, W) = 2 and d(F, G), d(R, S) = 1 and d(L, M) = 2
+"
+  (with-with ((with-courier ())
+              (with-simulation (simulation (*local-courier*)))
+              (with-address-dereferencing ()))
+    (let* ((dryad (spawn-process 'dryad :match-address (register)
+                                        :debug? t))
+           (dryad-address (process-public-address dryad)))
+      (blossom-let (original-tree :dryad dryad-address)
+          ((A :id (id 0 2)
+              :children (list (vv-edge A B))
+              :held-by-roots (list D)
+              :paused? T)
+           (B :id (id 2 2)
+              :children (list (vv-edge B C))
+              :internal-weight 2
+              :match-edge (vv-edge B C)
+              :parent (vv-edge B A)
+              :positive? nil)
+           (C :id (id 4 2)
+              :match-edge (vv-edge C B)
+              :parent (vv-edge C B))
+           (D :id (id 2 0)
+              :children (list (vv-edge D E))
+              :held-by-roots (list A))
+           (E :id (id 4 0)
+              :children (list (vv-edge E F))
+              :internal-weight 2
+              :match-edge (vv-edge E F)
+              :parent (vv-edge E D)
+              :positive? nil)
+           (F :id (id 6 0)
+              :match-edge (vv-edge F E)
+              :parent (vv-edge F E))
+           (G :id (id 7 0)
+              :match-edge (vv-edge G H)
+              :parent (vv-edge G H))
+           (H :id (id 9 0)
+              :children (list (vv-edge H G))
+              :internal-weight 2
+              :match-edge (vv-edge H G)
+              :parent (vv-edge H I)
+              :positive? nil)
+           (I :id (id 11 0)
+              :children (list (vv-edge I H))
+              :held-by-roots (list L)
+              :paused? T)
+           (J :id (id 9 2)
+              :match-edge (vv-edge J K)
+              :parent (vv-edge J K))
+           (K :id (id 11 2)
+              :children (list (vv-edge K J))
+              :internal-weight 2
+              :match-edge (vv-edge K J)
+              :parent (vv-edge K L)
+              :positive? nil)
+           (L :id (id 13 2)
+              :children (list (vv-edge L K))
+              :held-by-roots (list I))
+           (M :id (id 15 2)
+              :children (list (vv-edge M N))
+              :held-by-roots (list P)
+              :paused? T)
+           (N :id (id 17 2)
+              :children (list (vv-edge N O))
+              :internal-weight 2
+              :match-edge (vv-edge N O)
+              :parent (vv-edge N M)
+              :positive? nil)
+           (O :id (id 19 2)
+              :match-edge (vv-edge O N)
+              :parent (vv-edge O N))
+           (P :id (id 17 0)
+              :children (list (vv-edge P Q))
+              :held-by-roots (list M))
+           (Q :id (id 19 0)
+              :children (list (vv-edge Q R))
+              :internal-weight 2
+              :match-edge (vv-edge Q R)
+              :parent (vv-edge Q P)
+              :positive? nil)
+           (R :id (id 21 0)
+              :match-edge (vv-edge R Q)
+              :parent (vv-edge R Q))
+           (S :id (id 22 0)
+              :match-edge (vv-edge S U)
+              :parent (vv-edge S U))
+           (U :id (id 24 0)
+              :children (list (vv-edge U S))
+              :internal-weight 2
+              :match-edge (vv-edge U S)
+              :parent (vv-edge U V)
+              :positive? nil)
+           (V :id (id 26 0)
+              :children (list (vv-edge V U))
+              :held-by-roots (list Y)
+              :paused? T)
+           (W :id (id 24 2)
+              :match-edge (vv-edge W X)
+              :parent (vv-edge W X))
+           (X :id (id 26 2)
+              :children (list (vv-edge X W))
+              :internal-weight 2
+              :match-edge (vv-edge X W)
+              :parent (vv-edge X Y)
+              :positive? nil)
+           (Y :id (id 28 2)
+              :children (list (vv-edge Y X))
+              :held-by-roots (list V)))
+        (let ((supervisor-A (supervisor simulation
+                                        :recommendation ':hold
+                                        :weight 0
+                                        :edges (list (vv-edge B D))
+                                        :source-root (process-public-address A)
+                                        :target-root (process-public-address D)
+                                        :source-id (slot-value B 'anatevka::id)
+                                        :root-bucket (list
+                                                      (process-public-address D))))
+              (supervisor-I (supervisor simulation
+                                        :recommendation ':hold
+                                        :weight 0
+                                        :edges (list (vv-edge I K))
+                                        :source-root (process-public-address I)
+                                        :target-root (process-public-address L)
+                                        :source-id (slot-value I 'anatevka::id)
+                                        :root-bucket (list (process-public-address L))))
+              (supervisor-M (supervisor simulation
+                                        :recommendation ':hold
+                                        :weight 0
+                                        :edges (list (vv-edge N P))
+                                        :source-root (process-public-address M)
+                                        :target-root (process-public-address P)
+                                        :source-id (slot-value N 'anatevka::id)
+                                        :root-bucket (list
+                                                      (process-public-address P))))
+              (supervisor-V (supervisor simulation
+                                        :recommendation ':hold
+                                        :weight 0
+                                        :edges (list (vv-edge V X))
+                                        :source-root (process-public-address V)
+                                        :target-root (process-public-address Y)
+                                        :source-id (slot-value V 'anatevka::id)
+                                        :root-bucket (list (process-public-address Y)))))
+          (simulate-add-tree simulation original-tree)
+
+          ;; fill the dryad and add it to the simulation
+          (dolist (node original-tree)
+            (let* ((id (slot-value node 'anatevka::id))
+                   (address (process-public-address node))
+                   (sprouted? (not (null (anatevka::blossom-node-match-edge node)))))
+              (setf (gethash address (anatevka::dryad-ids dryad))       id
+                    (gethash address (anatevka::dryad-sprouted? dryad)) sprouted?)))
+          (simulation-add-event simulation (make-event :callback dryad))
+
+          (simulate-until-dead simulation supervisor-A)
+          (simulate-until-dead simulation supervisor-I)
+          (simulate-until-dead simulation supervisor-M)
+          (simulate-until-dead simulation supervisor-V)
+          (blossom-let (target-tree :dryad dryad-address)
+              ((A :id (id 0 2)
+                  :internal-weight 1/2
+                  :children (list (vv-edge A B)))
+               (B :id (id 2 2)
+                  :children (list (vv-edge B C))
+                  :internal-weight 3/2
+                  :match-edge (vv-edge B C)
+                  :parent (vv-edge B A)
+                  :positive? nil)
+               (C :id (id 4 2)
+                  :internal-weight 1/2
+                  :match-edge (vv-edge C B)
+                  :parent (vv-edge C B))
+               (D :id (id 2 0)
+                  :internal-weight 1/2
+                  :children (list (vv-edge D E)))
+               (E :id (id 4 0)
+                  :children (list (vv-edge E F))
+                  :internal-weight 3/2
+                  :match-edge (vv-edge E F)
+                  :parent (vv-edge E D)
+                  :positive? nil)
+               (F :id (id 6 0)
+                  :internal-weight 1/2
+                  :match-edge (vv-edge F E)
+                  :parent (vv-edge F E))
+               (G :id (id 7 0)
+                  :internal-weight 1/2
+                  :match-edge (vv-edge G H)
+                  :parent (vv-edge G H))
+               (H :id (id 9 0)
+                  :children (list (vv-edge H G))
+                  :internal-weight 3/2
+                  :match-edge (vv-edge H G)
+                  :parent (vv-edge H I)
+                  :positive? nil)
+               (I :id (id 11 0)
+                  :internal-weight 1/2
+                  :children (list (vv-edge I H)))
+               (J :id (id 9 2)
+                  :internal-weight 1/2
+                  :match-edge (vv-edge J K)
+                  :parent (vv-edge J K))
+               (K :id (id 11 2)
+                  :children (list (vv-edge K J))
+                  :internal-weight 3/2
+                  :match-edge (vv-edge K J)
+                  :parent (vv-edge K L)
+                  :positive? nil)
+               (L :id (id 13 2)
+                  :internal-weight 1/2
+                  :children (list (vv-edge L K)))
+               (M :id (id 15 2)
+                  :internal-weight 1/2
+                  :children (list (vv-edge M N)))
+               (N :id (id 17 2)
+                  :children (list (vv-edge N O))
+                  :internal-weight 3/2
+                  :match-edge (vv-edge N O)
+                  :parent (vv-edge N M)
+                  :positive? nil)
+               (O :id (id 19 2)
+                  :internal-weight 1/2
+                  :match-edge (vv-edge O N)
+                  :parent (vv-edge O N))
+               (P :id (id 17 0)
+                  :internal-weight 1/2
+                  :children (list (vv-edge P Q)))
+               (Q :id (id 19 0)
+                  :children (list (vv-edge Q R))
+                  :internal-weight 3/2
+                  :match-edge (vv-edge Q R)
+                  :parent (vv-edge Q P)
+                  :positive? nil)
+               (R :id (id 21 0)
+                  :internal-weight 1/2
+                  :match-edge (vv-edge R Q)
+                  :parent (vv-edge R Q))
+               (S :id (id 22 0)
+                  :internal-weight 1/2
+                  :match-edge (vv-edge S U)
+                  :parent (vv-edge S U))
+               (U :id (id 24 0)
+                  :children (list (vv-edge U S))
+                  :internal-weight 3/2
+                  :match-edge (vv-edge U S)
+                  :parent (vv-edge U V)
+                  :positive? nil)
+               (V :id (id 26 0)
+                  :internal-weight 1/2
+                  :children (list (vv-edge V U)))
+               (W :id (id 24 2)
+                  :internal-weight 1/2
+                  :match-edge (vv-edge W X)
+                  :parent (vv-edge W X))
+               (X :id (id 26 2)
+                  :children (list (vv-edge X W))
+                  :internal-weight 3/2
+                  :match-edge (vv-edge X W)
+                  :parent (vv-edge X Y)
+                  :positive? nil)
+               (Y :id (id 28 2)
+                  :internal-weight 1/2
+                  :children (list (vv-edge Y X))))
             (is (tree-equalp original-tree target-tree))))))))


### PR DESCRIPTION
Executive summary of changes:
1. Perform multireweight operation hold cluster scan before locking (and change from soft -> regular)
2. If the resulting minimum-weight edge recommendation extends external to the hold cluster, lock the target-root
3. Change `message-discover`'s boolean `repeat?` slot to `strategy`, which can be `:BUST` (formerly `NIL`), `:HIT` (formerly `T`), or `:STAY` (new option)
4. Modify the multireweight operation hold cluster scan and scans inside `CHECK-` commands to use `:STAY`
5. Update the `CHECK-REWEIGHT` command to take a set of roots and perform the check on all of them
6. Change the multireweight critical section to exactly match that of the reweight critical section modulo the choice of command arguments (this means adding `CHECK-REWEIGHT` and replacing the redundant multireweight versions of some of the commands with their reweight counterpart)
7. Add a new `START-INNER-MULTIREWEIGHT` command that is in charge of pushing the critical section onto the supervisor's process command stack
8. Delete the (now unused) redundant multireweight versions of the reweight commands

The `tests/` diff is struggling, but the new tests are:
1. `test-supervisor-multireweight-2-clusters`
2. `test-supervisor-multireweight-3-clusters`
3. `test-supervisor-multireweight-4-clusters`