### PR TITLE
Various improvements to logging utilities

### DIFF
--- a/src/dryad.lisp
+++ b/src/dryad.lisp
@@ -71,7 +71,8 @@ NOTE: In the basic implementation, these messages must be waiting for the DRYAD 
          (node-address (process-public-address node-process)))
     (log-entry :entry-type ':handling-sow
                :address node-address
-               :id node-id)
+               :id node-id
+               :type (type-of node-process))
     (schedule node-process (now))
     (setf (gethash node-address (dryad-ids       dryad)) node-id
           (gethash node-address (dryad-sprouted? dryad)) nil)))

--- a/src/dryad.lisp
+++ b/src/dryad.lisp
@@ -69,7 +69,7 @@ NOTE: In the basic implementation, these messages must be waiting for the DRYAD 
                                       :id node-id
                                       :debug? (process-debug? dryad)))
          (node-address (process-public-address node-process)))
-    (log-entry :entry-type 'handling-sow
+    (log-entry :entry-type ':handling-sow
                :address node-address
                :id node-id)
     (schedule node-process (now))
@@ -95,7 +95,7 @@ NOTE: In the basic implementation, these messages must be waiting for the DRYAD 
   "Handles a SPROUT message, indicating that a BLOSSOM-NODE has been matched (for the first time)."
   (with-slots (address) message
     (a:when-let ((id (gethash address (dryad-ids dryad))))
-      (log-entry :entry-type 'handling-sprout
+      (log-entry :entry-type ':handling-sprout
                  :address address
                  :id id)
       (setf (gethash address (dryad-sprouted? dryad)) t))))
@@ -191,7 +191,7 @@ NOTE: In the basic implementation, these messages must be waiting for the DRYAD 
 (define-process-upkeep ((dryad dryad)) (PROCESS-PAIRS pairs)
   "Iterates through `PAIRS' of addresses and sends corresponding WILT and REAP messages."
   (dolist (address-pair pairs)
-    (log-entry :entry-type 'processing-pair
+    (log-entry :entry-type ':processing-pair
                :pair address-pair)
     (send-message-batch #'make-message-wilt address-pair)
     (let ((id-pair (list (gethash (first address-pair) (dryad-ids dryad))
@@ -214,10 +214,10 @@ NOTE: In the basic implementation, these messages must be waiting for the DRYAD 
           ((children parent match-edge) topmost)
         (cond
           ((or children parent)
-           (log-entry :entry-type 'aborting-dryad-expansion
+           (log-entry :entry-type ':aborting-dryad-expansion
                       :reason 'tree-structure))
           (t
-           (log-entry :entry-type 'dryad-sending-expand
+           (log-entry :entry-type ':dryad-sending-expand
                       :sprout sprout
                       :topmost topmost
                       :match-edge match-edge)

--- a/src/logger.lisp
+++ b/src/logger.lisp
@@ -24,8 +24,8 @@
                             (source supervisor)
                             (entry-type (eql ':success))
                             &optional (stream *standard-output*))
-  (format stream "~5f: SUPERVISOR ~a closing.~%"
-          (getf entry ':time) (getf entry ':source)))
+  (format stream "~5f: SUPERVISOR ~a closing with success ~a.~%"
+          (getf entry ':time) (getf entry ':source) (getf entry ':success)))
 
 (defmethod print-log-entry (entry
                             (source blossom-node)

--- a/src/logger.lisp
+++ b/src/logger.lisp
@@ -111,14 +111,15 @@
                                 (set-difference start-processes done-processes)))))
 
 (defgeneric algorithmic-entry? (entry source)
-  (:documentation "Used to define which subset of `ENTRY' types emanating from `SOURCE' are critical to understanding algorithmic developments."))
+  (:documentation "Used to define which subset of `ENTRY' types emanating from `SOURCE' are critical to understanding algorithmic developments.")
+  (:method (entry source) nil))
 
 (defmethod algorithmic-entry? (entry (source supervisor))
-  (or (eql ':got-recommendation (getf entry ':entry-type))
-      (eql ':success (getf entry ':entry-type))
-      (eql ':reweighting (getf entry ':entry-type))
-      (eql ':rewinding (getf entry ':entry-type))
-      (eql ':multireweighting (getf entry ':entry-type))))
+  (member (getf entry ':entry-type) '(:got-recommendation
+                                      :success
+                                      :reweighting
+                                      :rewinding
+                                      :multireweighting)))
 
 (defun reduced-log (&optional (logger *logger*))
   "Trims log messages to only ones of primary interest (see `ALGORITHMIC-ENTRY?')."

--- a/src/logger.lisp
+++ b/src/logger.lisp
@@ -10,7 +10,7 @@
 
 (defmethod print-log-entry (entry
                             (source supervisor)
-                            (entry-type (eql 'GOT-RECOMMENDATION))
+                            (entry-type (eql ':got-recommendation))
                             &optional (stream *standard-output*))
   (format stream "~5f: SUPERVISOR ~a got recommendation ~a (~a; ~{~a~^ ~}) from root: ~a~%"
           (getf entry ':time)
@@ -22,14 +22,14 @@
 
 (defmethod print-log-entry (entry
                             (source supervisor)
-                            (entry-type (eql 'SUCCESS))
+                            (entry-type (eql ':success))
                             &optional (stream *standard-output*))
   (format stream "~5f: SUPERVISOR ~a closing.~%"
           (getf entry ':time) (getf entry ':source)))
 
 (defmethod print-log-entry (entry
                             (source blossom-node)
-                            (entry-type (eql 'SET-UP-BLOSSOM))
+                            (entry-type (eql ':set-up-blossom))
                             &optional (stream *standard-output*))
   "Log entry for when a blossom node finishes setting itself up."
   (format stream "~5f: BLOSSOM ~a completed setting up (peduncle: ~a; match: ~a; children: ~{~a~^ ~}; parent: ~a; petals: ~{~a~^ ~}; pistil: ~a)~%"
@@ -44,7 +44,7 @@
 
 (defmethod print-log-entry (entry
                             (source dryad)
-                            (entry-type (eql 'HANDLING-SOW))
+                            (entry-type (eql ':handling-sow))
                             &optional (stream *standard-output*))
   (format stream "~5f: Spawning blossom ~a at ~a.~%"
           (getf entry ':time)
@@ -59,22 +59,22 @@
   "Collects addresses of supervisors which either complete successfully or fail to complete at all."
   (loop :for entry :in entries
         :when (and (typep (getf entry ':source) 'supervisor)
-                   (eql 'SUCCESS (getf entry ':entry-type))
+                   (eql ':success (getf entry ':entry-type))
                    (eql T (getf entry ':success)))
           :collect (getf entry ':source) :into positive-processes
         :when (and (typep (getf entry ':source) 'supervisor)
-                   (eql 'GOT-RECOMMENDATION (getf entry ':entry-type))
+                   (eql ':got-recommendation (getf entry ':entry-type))
                    (eql ':HOLD (getf entry ':recommendation))
                    (address=
                     (blossom-edge-source-node (first (getf entry ':edges)))
                     (blossom-edge-target-node (first (getf entry ':edges)))))
           :collect (getf entry ':source) :into self-held-processes
         :when (and (typep (getf entry ':source) 'supervisor)
-                   (eql 'COMMAND (getf entry ':entry-type))
+                   (eql ':command (getf entry ':entry-type))
                    (eql ':START (getf entry ':command)))
           :collect (getf entry ':source) :into start-processes
         :when (and (typep (getf entry ':source) 'supervisor)
-                   (eql 'SUCCESS (getf entry ':entry-type)))
+                   (eql ':success (getf entry ':entry-type)))
           :collect (getf entry ':source) :into done-processes
         :finally (return (union (set-difference positive-processes self-held-processes)
                                 (set-difference start-processes done-processes)))))
@@ -86,30 +86,30 @@
     (dolist (entry (reverse (logger-entries log)) (reverse entries))
       (cond
         ((and (typep (getf entry ':source) 'supervisor)
-              (eql 'GOT-RECOMMENDATION (getf entry ':entry-type))
+              (eql ':got-recommendation (getf entry ':entry-type))
               (member (getf entry ':source) successful-processes))
          (push entry entries))
         ((or (and (typep (getf entry ':source) 'supervisor)
-                  (eql 'SUCCESS (getf entry ':entry-type))
+                  (eql ':success (getf entry ':entry-type))
                   (member (getf entry ':source) successful-processes))
              (and (typep (getf entry ':source) 'supervisor)
-                  (eql 'REWINDING (getf entry ':entry-type)))
+                  (eql ':rewinding (getf entry ':entry-type)))
              (and (typep (getf entry ':source) 'supervisor)
-                  (eql 'MULTIREWEIGHTING (getf entry ':entry-type)))
-             (and (eql 'MESSAGE-WILT (type-of (getf entry ':payload))))
-             (and (eql 'SPAWNED-FRESH-BLOSSOM (getf entry ':entry-type)))
-             (and (eql 'BLOSSOM-EXTINGUISHED (getf entry ':entry-type))))
+                  (eql ':multireweighting (getf entry ':entry-type)))
+             (and (eql ':message-wilt (type-of (getf entry ':payload))))
+             (and (eql ':spawned-fresh-blossom (getf entry ':entry-type)))
+             (and (eql ':blossom-extinguished (getf entry ':entry-type))))
          (push entry entries))
         ;; dryad logs
         ((and (typep (getf entry ':source) 'dryad)
               ;; dryad sowing
-              (or (eql 'HANDLING-SOW (getf entry ':entry-type))
-                  (eql 'HANDLING-SPROUT (getf entry ':entry-type))
-                  (eql 'PROCESSING-PAIR (getf entry ':entry-type))
+              (or (eql ':handling-sow (getf entry ':entry-type))
+                  (eql ':handling-sprout (getf entry ':entry-type))
+                  (eql ':processing-pair (getf entry ':entry-type))
                   ;; dryad expansion
-                  (and (eql 'COMMAND (getf entry ':entry-type))
-                       (eql 'SEND-EXPAND (getf entry ':command)))
-                  (eql 'DRYAD-SENDING-EXPAND (getf entry ':entry-type))))
+                  (and (eql ':command (getf entry ':entry-type))
+                       (eql ':send-expand (getf entry ':command)))
+                  (eql ':dryad-sending-expand (getf entry ':entry-type))))
          (push entry entries))))))
 
 
@@ -120,7 +120,7 @@
     (dolist (entry (reverse (logger-entries log)) (reverse entries))
       (cond
         ((and (typep (getf entry ':source) 'supervisor)
-              (eql 'GOT-RECOMMENDATION (getf entry ':entry-type))
+              (eql ':got-recommendation (getf entry ':entry-type))
               (or (and (not (null (getf entry ':source-root)))
                        (address= address (getf entry ':source-root)))
                   (and (not (null (not (null (getf entry ':target-root)))))

--- a/src/logger.lisp
+++ b/src/logger.lisp
@@ -113,11 +113,10 @@
          (push entry entries))))))
 
 
-(defun logs-for-address (log address)
+(defun supervisor-logs-for-address (logger address)
   "Trims log messages to only ones related to SUPERVISOR actions involving `ADDRESS'."
-  (let (entries
-        relevant-supervisors)
-    (dolist (entry (reverse (logger-entries log)) (reverse entries))
+  (let (entries relevant-supervisors)
+    (dolist (entry (reverse (logger-entries logger)) (reverse entries))
       (cond
         ((and (typep (getf entry ':source) 'supervisor)
               (eql ':got-recommendation (getf entry ':entry-type))

--- a/src/node.lisp
+++ b/src/node.lisp
@@ -309,7 +309,7 @@ evalutes to
     ((node blossom-node) (message message-broadcast-pingability))
   "Changes the pingability of `NODE' (and children / petals) to `PING-TYPE'."
   (with-slots (ping-type) message
-    (log-entry :entry-type 'changing-pingability
+    (log-entry :entry-type ':changing-pingability
                :old-pingability (blossom-node-pingable node)
                :new-pingability ping-type)
     (setf (blossom-node-pingable node) ping-type)

--- a/src/node.lisp
+++ b/src/node.lisp
@@ -167,26 +167,25 @@
                       :target-node (if target-node-p target-node target-vertex)))
 
 (defmethod print-object ((object blossom-edge) stream)
-  (print-unreadable-object (object stream :type nil :identity nil)
-    (if (and (blossom-edge-source-node object)
+  (if (and (blossom-edge-source-node object)
              (blossom-edge-source-vertex object)
              (address= (blossom-edge-source-node object)
                        (blossom-edge-source-vertex object)))
         (format stream "~a-"
                 (blossom-edge-source-vertex object))
-        (format stream "[~a: ~a--]"
+        (format stream "[~a: ~a-]"
                 (blossom-edge-source-node object)
                 (blossom-edge-source-vertex object)))
-    (format stream "--")
-    (if (and (blossom-edge-target-vertex object)
-             (blossom-edge-target-node object)
-             (address= (blossom-edge-target-vertex object)
-                       (blossom-edge-target-node object)))
-        (format stream "->~a"
-                (blossom-edge-target-vertex object))
-        (format stream "[->~a :~a]"
-                (blossom-edge-target-vertex object)
-                (blossom-edge-target-node object)))))
+  (format stream "-")
+  (if (and (blossom-edge-target-vertex object)
+           (blossom-edge-target-node object)
+           (address= (blossom-edge-target-vertex object)
+                     (blossom-edge-target-node object)))
+      (format stream "->~a"
+              (blossom-edge-target-vertex object))
+      (format stream "[->~a :~a]"
+              (blossom-edge-target-vertex object)
+              (blossom-edge-target-node object))))
 
 (defun edge= (x y)
   (check-type x blossom-edge)

--- a/src/operations/augment.lisp
+++ b/src/operations/augment.lisp
@@ -62,7 +62,7 @@
 (define-process-upkeep ((supervisor supervisor)) (AUGMENT edge)
   "Perform an augmentation along a given edge."
   (unless (process-lockable-aborting? supervisor)
-    (log-entry :entry-type 'augment
+    (log-entry :entry-type ':augment
                :from (blossom-edge-source-node edge)
                :to (blossom-edge-target-node edge))
     (sync-rpc (make-message-percolate :traversal-edge edge)

--- a/src/operations/contract.lisp
+++ b/src/operations/contract.lisp
@@ -103,7 +103,7 @@ PETAL-CHILD-EDGES: The list of child edges attached to the blossoms in the subtr
                                          :paused? t
                                          :debug? (process-debug? supervisor))))
       (schedule fresh-blossom (now))
-      (log-entry :entry-type 'spawned-fresh-blossom
+      (log-entry :entry-type ':spawned-fresh-blossom
                  :fresh-blossom fresh-blossom)
       (push (make-data-frame-contract
              :fresh-blossom (process-public-address fresh-blossom)
@@ -395,7 +395,7 @@ If we have a non-null peduncle edge (F -> C above), then we need to tell its sou
           (blossom-node-dryad node)         dryad
           ;; lastly, unpause our new blossom so that it can SCAN
           (blossom-node-paused? node)        nil)
-    (log-entry :entry-type 'SET-UP-BLOSSOM
+    (log-entry :entry-type ':set-up-blossom
                :peduncle-edge peduncle-edge
                :match-edge (blossom-node-match-edge node)
                :children (blossom-node-children node)

--- a/src/operations/expand.lisp
+++ b/src/operations/expand.lisp
@@ -114,7 +114,7 @@
      (send-message (message-reply-channel message)
                    (make-message-rpc-done)))
     (t
-     (log-entry :entry-type 'expanding-blossom
+     (log-entry :entry-type ':expanding-blossom
                 :blossom node
                 :petals (blossom-node-petals node)
                 :match-edge (blossom-node-match-edge node))
@@ -169,8 +169,8 @@
   ;;
   ;; it doesn't make sense to expand unmatched blossoms (but the dryad might try)
   (unless (blossom-node-match-edge node)
-    (log-entry :entry-type 'aborting-expand-blossom
-               :reason 'mateless-blossom
+    (log-entry :entry-type ':aborting-expand-blossom
+               :reason ':mateless-blossom
                :blossom node)
     (send-message reply-channel (make-message-rpc-done))
     (finish-handler))
@@ -388,6 +388,6 @@ In the right diagram, b0 is both the `root-node' and the `matched-node', because
   ;; NOTE: There's no data frame to pop.
   (when reply-channel
     (send-message reply-channel (make-message-rpc-done)))
-  (log-entry :entry-type 'blossom-extinguished
+  (log-entry :entry-type ':blossom-extinguished
              :blossom node)
   (setf (blossom-node-wilting node) t))

--- a/src/operations/multireweight.lisp
+++ b/src/operations/multireweight.lisp
@@ -78,8 +78,8 @@ After collecting the `HOLD-CLUSTER', we then `CHECK-PRIORITY' to determine if we
         (with-replies (replies :returned? returned?)
           (send-message-batch #'payload-constructor root-bucket)
           (when (some #'null replies)
-            (log-entry :entry-type 'aborting-multireweight
-                       :reason 'root-collection-failed
+            (log-entry :entry-type ':aborting-multireweight
+                       :reason ':root-collection-failed
                        :hold-cluster cluster
                        :held-by-roots root-bucket)
             (setf (process-lockable-aborting? supervisor) t)
@@ -87,8 +87,8 @@ After collecting the `HOLD-CLUSTER', we then `CHECK-PRIORITY' to determine if we
           (setf hold-cluster (reduce #'address-union (list* cluster replies)))
           ;; don't bother _multi_reweighting if we're in a cluster of 1.
           (when (endp (rest hold-cluster))
-            (log-entry :entry-type 'aborting-multireweight
-                       :reason 'cluster-of-one
+            (log-entry :entry-type ':aborting-multireweight
+                       :reason ':cluster-of-one
                        :hold-cluster hold-cluster)
             (setf (process-lockable-aborting? supervisor) t)
             (finish-handler))
@@ -108,8 +108,8 @@ After collecting the `HOLD-CLUSTER', we then `CHECK-PRIORITY' to determine if we
                     (send-message-batch #'make-message-id-query hold-cluster)
         (let ((cluster-id (reduce #'min-id replies)))
           (unless (equalp source-id (min-id source-id cluster-id))
-            (log-entry :entry-type 'aborting-multireweight
-                       :reason 'dont-have-priority
+            (log-entry :entry-type ':aborting-multireweight
+                       :reason ':dont-have-priority
                        :source-root source-root
                        :hold-cluster hold-cluster)
             (setf (process-lockable-aborting? supervisor) t)))))))
@@ -117,7 +117,7 @@ After collecting the `HOLD-CLUSTER', we then `CHECK-PRIORITY' to determine if we
 (define-process-upkeep ((supervisor supervisor)) (SET-HELD-BY-ROOTS hold-cluster)
   "Sets the `held-by-roots' slot on every element in the `HOLD-CLUSTER' to equal the `HOLD-CLUSTER'. I don't think this is _strictly_ necessary, but could speed up some future convergecasts."
   (unless (process-lockable-aborting? supervisor)
-    (log-entry :entry-type 'set-held-by-roots
+    (log-entry :entry-type ':set-held-by-roots
                :held-by-roots hold-cluster)
     (flet ((payload-constructor ()
              (make-message-set :slots '(held-by-roots) :values `(,hold-cluster))))
@@ -140,7 +140,7 @@ After collecting the `HOLD-CLUSTER', we then `CHECK-PRIORITY' to determine if we
                 :do (assert (not (minusp (message-pong-weight reply))))
                     (setf internal-pong
                           (unify-pongs internal-pong reply)))
-          (log-entry :entry-type 'multireweight-broadcast-scan-result
+          (log-entry :entry-type ':multireweight-broadcast-scan-result
                      :hold-cluster roots
                      :internal-pong internal-pong)
           (process-continuation supervisor

--- a/src/operations/reweight.lisp
+++ b/src/operations/reweight.lisp
@@ -144,7 +144,7 @@
           (loop :for reply :in replies :unless (null reply)
                 :do (setf check-pong (unify-pongs check-pong reply)))
           (when (< (message-pong-weight check-pong) original-weight)
-            (log-entry :entry-type 'check-reweight-aborting
+            (log-entry :entry-type ':check-reweight-aborting
                        :original-pong original-pong
                        :check-pong check-pong)
             (setf (process-lockable-aborting? supervisor) t)))))))
@@ -153,7 +153,7 @@
     (BROADCAST-REWEIGHT roots weight)
   "Instruct some `ROOTS' to reweight their trees by `WEIGHT'."
   (unless (process-lockable-aborting? supervisor)
-    (log-entry :entry-type 'reweighting
+    (log-entry :entry-type ':reweighting
                :weight weight
                :roots roots)
     (flet ((payload-constructor ()
@@ -182,7 +182,7 @@
           ;; potentially rewind from the initial recommendation reweighting.
           (let ((maximum-rewinding (- original-amount carry))
                 (minimum-weight-edge (message-pong-weight rewinding-pong)))
-            (log-entry :entry-type 'check-rewinding-details
+            (log-entry :entry-type ':check-rewinding-details
                        :original-amount original-amount
                        :carry carry
                        :minimum-weight-edge minimum-weight-edge
@@ -210,7 +210,7 @@
                 (when (zerop carry)
                   (setf rewinding-amount (/ rewinding-amount 2)))
                 (let ((new-carry (- carry rewinding-amount)))
-                  (log-entry :entry-type 'rewinding
+                  (log-entry :entry-type ':rewinding
                              :roots roots
                              :amount rewinding-amount
                              :overall new-carry
@@ -254,11 +254,11 @@
   (with-slots (weight) message
     (with-slots (internal-weight) node
       (incf internal-weight weight)
-      (log-entry :entry-type 'reweight-details
+      (log-entry :entry-type ':reweight-details
                  :amount weight
                  :new-internal-weight internal-weight)
       (when (minusp internal-weight)
-        (log-entry :entry-type 'negative-internal-weight
+        (log-entry :entry-type ':negative-internal-weight
                    :internal-weight internal-weight))
       (setf weight (- weight))
       (push-broadcast-frame :targets (mapcar #'blossom-edge-target-node

--- a/src/operations/reweight.lisp
+++ b/src/operations/reweight.lisp
@@ -89,15 +89,25 @@
         ;;  - `AUGMENT': the `target-root' (and potentially its hold cluster)
         ;;  - `GRAFT': one end of the barbell
         ;;  - `EXPAND' or `CONTRACT': nothing
+        (log-entry :entry-type ':gathering-targets
+                   :pong (copy-message-pong pong)
+                   :source-root source-root
+                   :target-root target-root
+                   :targets targets)
         (cond
           ((null target-root)
            (push source-root targets))
           (t
            (sync-rpc (make-message-convergecast-collect-roots)
                (target-cluster target-root :returned? returned?)
-               (setf targets (remove-duplicates
-                              (append (list source-root target-root) target-cluster)
-                              :test #'address=)))))))))
+             (setf targets (remove-duplicates
+                            (append (list source-root target-root) target-cluster)
+                            :test #'address=))
+             (log-entry :entry-type ':collected-target-cluster
+                        :source-root source-root
+                        :target-root target-root
+                        :target-cluster target-cluster
+                        :targets targets))))))))
 
 (define-process-upkeep ((supervisor supervisor)) (START-INNER-REWEIGHT)
   "The reweight 'critical section':
@@ -143,6 +153,9 @@
                       (send-message-batch #'payload-constructor roots)
           (loop :for reply :in replies :unless (null reply)
                 :do (setf check-pong (unify-pongs check-pong reply)))
+          (log-entry :entry-type ':check-reweight-details
+                     :original-pong original-pong
+                     :check-pong check-pong)
           (when (< (message-pong-weight check-pong) original-weight)
             (log-entry :entry-type ':check-reweight-aborting
                        :original-pong original-pong

--- a/src/operations/scan.lisp
+++ b/src/operations/scan.lisp
@@ -258,7 +258,7 @@ When INTERNAL-ROOT-SET is supplied, discard HOLD recommendations which emanate f
          (internal-roots (or (message-scan-internal-roots scan-message)
                              (list local-root)))
          (strategy (slot-value scan-message 'strategy)))
-    (log-entry :entry-type 'starting-scan
+    (log-entry :entry-type ':starting-scan
                :deweight weight)
     (push (make-data-frame-scan :local-root local-root
                                 :local-blossom local-blossom
@@ -374,7 +374,7 @@ NOTE: this command is only installed when NODE is a vertex."
     (with-slots (recommendation root-bucket) pong
       (cond
         (reply-channel
-         (log-entry :entry-type 'pong-throw)
+         (log-entry :entry-type ':pong-throw)
          (if (blossom-node-wilting node)
              (send-message reply-channel (make-pong node))
              (send-message reply-channel pong)))
@@ -408,7 +408,7 @@ NOTE: this command is only installed when NODE is a vertex."
                                             :node-class (type-of node)
                                             :node-dryad (blossom-node-dryad node)
                                             :debug? (process-debug? node))))
-           (log-entry :entry-type 'spawn-supervisor
+           (log-entry :entry-type ':spawn-supervisor
                       :pong pong
                       :address (process-public-address supervisor))
            (push pong (process-data-stack supervisor))
@@ -452,7 +452,7 @@ NOTE: this command is only installed when NODE is a vertex."
                             :edges edges
                             :source-root root
                             :source-id id)))
-      (log-entry :entry-type 'handle-ping
+      (log-entry :entry-type ':handle-ping
                  :ping-type (type-of message)
                  :pingability (blossom-node-pingable node)
                  :vv-distance (vertex-vertex-distance (blossom-node-id node) id)
@@ -477,7 +477,7 @@ This handler is responsible for actually assigning a recommended-next-move for t
     ;; if we haven't yet started crawling up parent instead of pistil...
     (unless (blossom-edge-target-node last-edge)
       ;; ... include these internal weights
-      (log-entry :entry-type 'DECF-WEIGHT
+      (log-entry :entry-type ':decf-weight
                  :old-value (message-pong-weight pong)
                  :delta (blossom-node-internal-weight node))
       (decf (message-pong-weight pong)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -66,4 +66,14 @@
    #:message-discovery-future-distance  ; ACCESSOR
    #:message-sprout-address             ; ACCESSOR
    #:message-wilting-address            ; ACCESSOR
-   ))
+   )
+
+  ;; logger.lisp
+  (:export
+   #:supervisor-logs-for-address        ; FUNCTION
+   #:successful-supervisors             ; FUNCTION
+   #:algorithmic-entry?                 ; GENERIC FUNCTION
+   #:reduced-log                        ; FUNCTION
+   #:print-reduced-log                  ; FUNCTION
+   )
+  )

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -75,5 +75,8 @@
    #:algorithmic-entry?                 ; GENERIC FUNCTION
    #:reduced-log                        ; FUNCTION
    #:print-reduced-log                  ; FUNCTION
+   #:debug-entry?                       ; GENERIC FUNCTION
+   #:debug-log                          ; FUNCTION
+   #:print-debug-log                    ; FUNCTION
    )
   )

--- a/src/supervisor.lisp
+++ b/src/supervisor.lisp
@@ -75,7 +75,7 @@ PONG: The PONG that this process received at its START."
   "Set up initial state: the stack frame and which procedure to branch on."
   (let ((pong (pop (process-data-stack supervisor))))
     (with-slots (edges weight source-root target-root recommendation) pong
-      (log-entry :entry-type 'got-recommendation
+      (log-entry :entry-type ':got-recommendation
                  :source-root source-root
                  :target-root target-root
                  :recommendation recommendation
@@ -90,7 +90,7 @@ PONG: The PONG that this process received at its START."
           ;; with `ENSURE-ABORTING' which crashes the algorithm if `CHECK-PONG'
           ;; doesn't cause this supervisor to abort.
           ((minusp weight)
-           (log-entry :entry-type 'invalid-recommendation :weight weight)
+           (log-entry :entry-type ':invalid-recommendation :weight weight)
            (process-continuation supervisor
                                  `(CHECK-PONG ,pong)
                                  `(ENSURE-ABORTING ,pong)
@@ -112,7 +112,7 @@ PONG: The PONG that this process received at its START."
           ;; set `returned?' to handle RTSes gracefully as we
           ;; (intentionally) don't have an aborting? guard
           (set-result source-root :returned? returned?)
-        (log-entry :entry-type 'success
+        (log-entry :entry-type ':success
                    :success (not (process-lockable-aborting? supervisor)))
         (process-die)))))
 
@@ -128,7 +128,7 @@ PONG: The PONG that this process received at its START."
       (with-replies (values-lists) (send-message-batch #'payload-constructor roots)
         (loop :for (parent pistil match-edge) :in values-lists
               :do (when (or parent pistil match-edge)
-                    (log-entry :entry-type 'check-roots-aborting
+                    (log-entry :entry-type ':check-roots-aborting
                                :roots roots
                                :values-lists values-lists
                                :parent parent
@@ -154,7 +154,7 @@ PONG: The PONG that this process received at its START."
            (blossom-edge-source-vertex
             (car (last (message-pong-edges stale-pong))))
            :message-type message-pong :message-unpacker identity)
-        (log-entry :entry-type 'local-pong-recommendation
+        (log-entry :entry-type ':local-pong-recommendation
                    :recommendation (message-pong-recommendation local-pong))
         ;; send a ping to the far vertex with this local weight
         (let ((local-blossom (blossom-edge-target-node

--- a/tests/node.lisp
+++ b/tests/node.lisp
@@ -11,6 +11,12 @@
   x
   y)
 
+(defmethod print-object ((object grid-location) stream)
+  (print-unreadable-object (object stream :type nil :identity nil)
+    (format stream "(~a, ~a)"
+            (grid-location-x object)
+            (grid-location-y object))))
+
 (defmethod min-id ((x grid-location) (y grid-location))
   (cond
     ((< (grid-location-x x) (grid-location-x y))


### PR DESCRIPTION
```lisp
(with-transient-logger () (test-blossom-bulk-pair) (print-reduced-log))
```

gives

```
  0.0: [#<DRYAD 48438>] sowed BLOSSOM-NODE #<48439> at #<(3, 0)>
  0.0: [#<DRYAD 48438>] sowed BLOSSOM-NODE #<48440> at #<(3, 2)>
 0.24: [#<SUPERVISOR 48445>] got AUGMENT 2 #<48439>--->#<48440> from #<48439>
 0.96: [#<SUPERVISOR 48445>] reweighting roots (#<48439>) by 2
 1.54: [#<SUPERVISOR 48445>] closing with success
 1.74: [#<SUPERVISOR 48475>] got AUGMENT 0 #<48440>--->#<48439> from #<48440>
 2.36: [#<SUPERVISOR 48475>] closing with success
  2.5: [#<DRYAD 48438>] processing match (#<48440> #<48439>)
```