### PR TITLE
Establish a mutex-like claim on the hold cluster before MRW scanning

### DIFF
--- a/src/logger.lisp
+++ b/src/logger.lisp
@@ -146,14 +146,47 @@
 
 (defmethod print-log-entry (entry
                             (source supervisor)
-                            (entry-type (eql ':aborting-multireweight-negative-pong))
+                            (entry-type (eql ':multireweight-broadcast-scan-result))
                             &optional (stream *standard-output*))
-  (format stream "~5f: [~a] aborting ~a (~a)'s MRW bc the cluster scan returned a negative-weight pong ~a for hold-cluster (~{~a~^ ~})~%"
+  (format stream "~5f: [~a] ~a (~a)'s MRW cluster scan returned pong (~a ~a ~{~a~^ ~} target-root ~a) for hold-cluster (~{~a~^ ~})~%"
           (getf entry ':time)
           (getf entry ':source)
           (getf entry ':source-root)
           (getf entry ':source-id)
-          (getf entry ':internal-pong)
+          (getf entry ':recommendation)
+          (getf entry ':weight)
+          (getf entry ':edges)
+          (getf entry ':target-root)
+          (getf entry ':hold-cluster)))
+
+(defmethod print-log-entry (entry
+                            (source supervisor)
+                            (entry-type (eql ':aborting-multireweight-negative-pong))
+                            &optional (stream *standard-output*))
+  (format stream "~5f: [~a] aborting ~a (~a)'s MRW bc the cluster scan returned a negative-weight pong (~a ~a ~{~a~^ ~} target-root ~a) for hold-cluster (~{~a~^ ~})~%"
+          (getf entry ':time)
+          (getf entry ':source)
+          (getf entry ':source-root)
+          (getf entry ':source-id)
+          (getf entry ':recommendation)
+          (getf entry ':weight)
+          (getf entry ':edges)
+          (getf entry ':target-root)
+          (getf entry ':hold-cluster)))
+
+(defmethod print-log-entry (entry
+                            (source supervisor)
+                            (entry-type (eql ':aborting-multireweight-zero-pong))
+                            &optional (stream *standard-output*))
+  (format stream "~5f: [~a] aborting ~a (~a)'s MRW bc the cluster scan returned a zero-weight pong (~a ~a ~{~a~^ ~} target-root ~a) for hold-cluster (~{~a~^ ~})~%"
+          (getf entry ':time)
+          (getf entry ':source)
+          (getf entry ':source-root)
+          (getf entry ':source-id)
+          (getf entry ':recommendation)
+          (getf entry ':weight)
+          (getf entry ':edges)
+          (getf entry ':target-root)
           (getf entry ':hold-cluster)))
 
 ;;;

--- a/src/node.lisp
+++ b/src/node.lisp
@@ -266,8 +266,10 @@ evalutes to
   (values nil :type list))
 
 (defstruct (message-id-query (:include message))
-  "Replies with the minimum ID at this macrovertex."
-  )
+  "Replies with the minimum ID at this macrovertex.")
+
+(defstruct (message-scan-loop-t (:include message))
+  "Instructs the node to act as if its last scan was unsuccessful.")
 
 ;;;
 ;;; message handlers for BLOSSOM-NODE
@@ -384,6 +386,13 @@ evalutes to
                                       :address (process-public-address node)))
   (setf (blossom-node-wilting node) t))
 
+(define-rpc-handler handle-message-scan-loop-t
+    ((node blossom-node) (message message-scan-loop-t))
+  "When a node is poised to `SCAN-LOOP', ensure that repeat? is T."
+  (when (eql 'SCAN-LOOP (first (first (process-command-stack node))))
+    (setf (first (process-command-stack node)) `(SCAN-LOOP t))
+    t))
+
 ;;;
 ;;; blossom message dispatch table
 ;;;
@@ -441,7 +450,8 @@ evalutes to
   
   (message-sprout                     'handle-message-sprout-on-blossom)
   
-  (message-id-query                   'handle-message-id-query))
+  (message-id-query                   'handle-message-id-query)
+  (message-scan-loop-t                'handle-message-scan-loop-t))
 
 ;;;
 ;;; basic command definitions for BLOSSOM-NODE

--- a/src/operations/multireweight.lisp
+++ b/src/operations/multireweight.lisp
@@ -145,7 +145,7 @@ After collecting the `hold-cluster', we then `CHECK-PRIORITY' to determine if we
                      :log-level 1
                      :roots roots)
           (setf (process-lockable-aborting? supervisor) t))
-        (setf claimed-roots (remove nil replies))))))
+        (setf claimed-roots (nconc claimed-roots (remove nil replies)))))))
 
 (define-process-upkeep ((supervisor supervisor)) (BROADCAST-SCAN-MULTIREWEIGHT roots)
   "Now that we know the full `HOLD-CLUSTER', we `SCAN' each, and aggregate the results in order to make a reweighting decision."

--- a/src/supervisor.lisp
+++ b/src/supervisor.lisp
@@ -69,7 +69,7 @@ PONG: The PONG that this process received at its START."
   (:method ((recommendation (eql ':EXPAND)))
     'START-EXPAND)
   (:method ((recommendation (eql ':HOLD)))
-    'START-MULTIREWEIGHT))
+    'START-HOLD))
 
 (define-process-upkeep ((supervisor supervisor)) (START)
   "Set up initial state: the stack frame and which procedure to branch on."

--- a/tests/operations/multireweight.lisp
+++ b/tests/operations/multireweight.lisp
@@ -1650,7 +1650,8 @@ d(B, D), d(H, J), d(N, P) = 2 and d(F, G), d(L, M) = 1
                   :positive? nil)
                (I :id (id 11 0)
                   :internal-weight 0
-                  :children (list (vv-edge I H)))
+                  :children (list (vv-edge I H))
+                  :held-by-roots (list L))
                (J :id (id 9 2)
                   :internal-weight 0
                   :match-edge (vv-edge J K)
@@ -1666,31 +1667,30 @@ d(B, D), d(H, J), d(N, P) = 2 and d(F, G), d(L, M) = 1
                   :children (list (vv-edge L K))
                   :held-by-roots (list I))
                (M :id (id 14 2)
-                  :internal-weight 0
-                  :children (list (vv-edge M N))
-                  :held-by-roots (list P))
+                  :internal-weight 1
+                  :children (list (vv-edge M N)))
                (N :id (id 16 2)
                   :children (list (vv-edge N O))
-                  :internal-weight 2
+                  :internal-weight 1
                   :match-edge (vv-edge N O)
                   :parent (vv-edge N M)
                   :positive? nil)
                (O :id (id 18 2)
-                  :internal-weight 0
+                  :internal-weight 1
                   :match-edge (vv-edge O N)
                   :parent (vv-edge O N))
                (P :id (id 16 0)
-                  :internal-weight 0
+                  :internal-weight 1
                   :children (list (vv-edge P Q))
                   :held-by-roots (list M))
                (Q :id (id 18 0)
                   :children (list (vv-edge Q R))
-                  :internal-weight 2
+                  :internal-weight 1
                   :match-edge (vv-edge Q R)
                   :parent (vv-edge Q P)
                   :positive? nil)
                (R :id (id 20 0)
-                  :internal-weight 0
+                  :internal-weight 1
                   :match-edge (vv-edge R Q)
                   :parent (vv-edge R Q)))
             (is (tree-equalp original-tree target-tree))))))))


### PR DESCRIPTION
The original syndrome was a reweight by zero indefinitely, e.g.:

```
2675.: [#<D-S 573423>] got HOLD 0 #<23776>--->#<22081> from #<23776> w/ root-bucket (#<22120>)
2675.: [#<D-S 573532>] got HOLD 0 #<19540>--->#<19560> from #<19575> w/ root-bucket (#<19585>)
2762.: [#<D-S 586941>] got HOLD 0 #<19585>--->#<19562> from #<19585> w/ root-bucket (#<19575> #<22118>)
2923.: [#<D-S 586941>] reweighting roots (#<22118> #<18122> #<14973> #<19570> #<25451> #<22120> #<23776> #<15015> #<12197> #<18154> #<15017> #<22132> #<19575> #<19585>) by 0
2940.: [#<D-S 586941>] closing with success
2958.: [#<D-S 615460>] got HOLD 0 #<19585>--->#<19562> from #<19585> w/ root-bucket (#<19575> #<22118>)
3073.: [#<D-S 615460>] reweighting roots (#<22118> #<18122> #<14973> #<19570> #<25451> #<22120> #<23776> #<15015> #<12197> #<18154> #<15017> #<22132> #<19575> #<19585>) by 0
3091.: [#<D-S 615460>] closing with success
3151.: [#<D-S 573532>] reweighting roots (#<19585> #<22132> #<15017> #<18154> #<12197> #<15015> #<23776> #<22120> #<25451> #<19570> #<14973> #<18122> #<22118> #<19575>) by 0
3181.: [#<D-S 573532>] closing with success
3192.: [#<D-S 646635>] got HOLD 0 #<15015>--->#<19592> from #<15015> w/ root-bucket (#<12197> #<22118> #<18154> #<15017>)
3192.: [#<D-S 646665>] got HOLD 0 #<19540>--->#<19560> from #<19575> w/ root-bucket (#<19585>)
3302.: [#<D-S 646665>] reweighting roots (#<19585> #<22132> #<15017> #<18154> #<12197> #<15015> #<23776> #<22120> #<25451> #<19570> #<14973> #<18122> #<22118> #<19575>) by 0
3334.: [#<D-S 646665>] closing with success
3418.: [#<D-S 676192>] got HOLD 0 #<19585>--->#<19562> from #<19585> w/ root-bucket (#<19575> #<22118>)
3445.: [#<D-S 646635>] reweighting roots (#<18154> #<18122> #<19585> #<19575> #<14973> #<19570> #<25451> #<22120> #<23776> #<22132> #<22118> #<12197> #<15017> #<15015>) by 0
3464.: [#<D-S 646635>] closing with success
3544.: [#<D-S 692400>] got HOLD 0 #<15015>--->#<19592> from #<15015> w/ root-bucket (#<12197> #<22118> #<18154> #<15017>)
3581.: [#<D-S 676192>] reweighting roots (#<22118> #<18122> #<14973> #<19570> #<25451> #<22120> #<23776> #<15015> #<12197> #<18154> #<15017> #<22132> #<19575> #<19585>) by 0
3615.: [#<D-S 676192>] closing with success
3625.: [#<D-S 703377>] got HOLD 0 #<22132>--->#<23786> from #<22132> w/ root-bucket (#<15017> #<25451> #<22118> #<22120> #<23776>)
3743.: [#<D-S 703377>] reweighting roots (#<25451> #<22120> #<22118> #<18122> #<19585> #<19575> #<14973> #<19570> #<15017> #<18154> #<12197> #<15015> #<23776> #<22132>) by 0
3777.: [#<D-S 703377>] closing with success
3908.: [#<D-S 692400>] reweighting roots (#<18154> #<18122> #<19585> #<19575> #<14973> #<19570> #<25451> #<22120> #<23776> #<22132> #<22118> #<12197> #<15017> #<15015>) by 0
3945.: [#<D-S 692400>] closing with success
4072.: [#<D-S 573423>] reweighting roots (#<22120> #<22118> #<18122> #<19585> #<19575> #<14973> #<19570> #<15017> #<18154> #<12197> #<15015> #<25451> #<22132> #<23776>) by 0
4119.: [#<D-S 573423>] closing with success
...
```

After telling the supervisor to abort in this case, we still get a livelock. We first explored scanning wider next time (via injecting `SCAN-LOOP t` into the source-root's command stack) so that the time between scan-interruptions increases, giving a heavily-interrupted root time to get to the end of its own self-initiated scan. This, however, just makes the livelock less likely but doesn't eliminate it completely.

The true "root cause" is that, as the problem graph gets denser, hold clusters get bigger, and then we get a combinatorial explosion of scan-interrupts that starves some of the roots / results in a livelock-like scenario.

Thus, we need a way to ensure only one root in the hold cluster scans the cluster. However, we can’t use the regular lock because need to also lock the potential target-root and its cluster once we get to the inner critical section AND either of the following lock-based approaches has flaws:

1. if we just extend the lock, we open ourselves up to livelock between the cluster and the target
2. if we instead unlock the cluster and then re-lock the cluster and the target, we avoid (1), but open ourselves up to livelock within the cluster (another root in our cluster could get to the first lock before we get to the second lock, etc.)

This implies that we need a new mechanism to ensure only one root scans the cluster. Implementing a lower-tier form of `BROADCAST-LOCK` is one idea, but this is potentially quite hairy (having a higher-tier lock blow away a lower-tier lock without leaving hanging pointers/latches). Luckily, the `MULTIREWEIGHT-BROADCAST-SCAN` only targets the roots in the hold cluster, and it’s okay if the scans get interrupted by an external standard lock, so I we can just set/unset a flag on the roots. We call this "claiming" and "releasing" the set of roots in the hold-cluster, and it follows a pattern similar to `BROADCAST-LOCK`/`BROADCAST-UNLOCK`. At any point in time, only one root in the cluster can have a claim over the cluster.