### PR TITLE
Revert HOLD preference; instead don't trust reweighting negative nodes

### DIFF
--- a/src/logger.lisp
+++ b/src/logger.lisp
@@ -108,16 +108,6 @@
 
 (defmethod print-log-entry (entry
                             (source supervisor)
-                            (entry-type (eql ':check-reweight-aborting-lower-precedence))
-                            &optional (stream *standard-output*))
-  (format stream "~5f: [~a] aborting reweight because we got a lower-precedence rec (~a < ~a)~%"
-          (getf entry ':time)
-          (getf entry ':source)
-          (getf entry ':check-pong-rec)
-          (getf entry ':original-rec)))
-
-(defmethod print-log-entry (entry
-                            (source supervisor)
                             (entry-type (eql ':reweighting))
                             &optional (stream *standard-output*))
   (format stream "~5f: [~a] reweighting roots (~{~a~^ ~}) by ~a~%"

--- a/src/node.lisp
+++ b/src/node.lisp
@@ -128,7 +128,13 @@
     :initform nil
     :initarg :claimed?
     :type boolean
-    :documentation "If T, this blossom is claimed as part of a hold-cluster."))
+    :documentation "If T, this blossom is claimed as part of a hold-cluster.")
+   (stashed-weight
+    :accessor blossom-node-stashed-weight
+    :initarg :stashed-weight
+    :initform nil
+    :type (or null real)
+    :documentation "Used to stash the internal weights of negative nodes during reweights."))
   (:documentation "Embodies a blossom in the blossom algorithm."))
 
 ;;;
@@ -476,7 +482,9 @@ evalutes to
   
   (message-id-query                   'handle-message-id-query)
   (message-claim-root                 'handle-message-claim-root)
-  (message-release-root               'handle-message-release-root))
+  (message-release-root               'handle-message-release-root)
+  (message-broadcast-stash-weight     'handle-message-broadcast-stash-weight)
+  (message-broadcast-unstash-weight   'handle-message-broadcast-unstash-weight))
 
 ;;;
 ;;; basic command definitions for BLOSSOM-NODE

--- a/src/operations/reweight.lisp
+++ b/src/operations/reweight.lisp
@@ -177,28 +177,7 @@
                              :log-level 1
                              :original-weight original-weight
                              :check-pong-weight check-pong-weight)
-                  (setf (process-lockable-aborting? supervisor) t))
-                ;; if the check-pong rec is HOLD now but it wasn't originally, abort
-                (when (and (eql ':hold check-pong-rec)
-                           (not (eql check-pong-rec original-rec))
-                           (not (address= original-target check-pong-target)))
-                  (log-entry :entry-type ':check-reweight-aborting-lower-precedence
-                             :log-level 1
-                             :original-rec original-rec
-                             :original-target original-target
-                             :check-pong-rec check-pong-rec
-                             :check-pong-target check-pong-target)
-                  (setf (process-lockable-aborting? supervisor) t))
-                ;; if the check-pong rec is HOLD from a root not in targets, abort
-                (when (and (eql ':hold check-pong-rec)
-                           (not (member check-pong-target targets :test #'address=)))
-                  (log-entry :entry-type ':check-reweight-aborting-new-root
-                             :log-level 1
-                             :original-rec original-rec
-                             :original-target original-target
-                             :check-pong-rec check-pong-rec
-                             :check-pong-target check-pong-target
-                             :targets targets))))))))))
+                  (setf (process-lockable-aborting? supervisor) t))))))))))
 
 (define-process-upkeep ((supervisor supervisor))
     (BROADCAST-REWEIGHT roots weight)

--- a/src/operations/reweight.lisp
+++ b/src/operations/reweight.lisp
@@ -89,7 +89,6 @@
         ;;  - `AUGMENT': the `target-root' (and potentially its hold cluster)
         ;;  - `GRAFT': one end of the barbell
         ;;  - `EXPAND' or `CONTRACT': nothing
-        ;;  - `HOLD': same as `AUGMENT' + other unique roots in `root-bucket'
         (log-entry :entry-type ':gathering-targets
                    :pong (copy-message-pong pong)
                    :source-root source-root
@@ -101,8 +100,7 @@
               (target-cluster target-root :returned? returned?)
             (setf targets (remove-duplicates
                            (append (list source-root target-root)
-                                   target-cluster
-                                   root-bucket)
+                                   target-cluster)
                            :test #'address=))
             (log-entry :entry-type ':collected-target-cluster
                        :source-root source-root

--- a/src/operations/scan.lisp
+++ b/src/operations/scan.lisp
@@ -130,6 +130,12 @@ When INTERNAL-ROOT-SET is supplied, discard HOLD recommendations which emanate f
         ((and (eql ':hold y-rec)
               (member y-root internal-root-set :test #'address=))
          x)
+        ;; prefer non-zero `AUGMENT's (which become `REWEIGHT's) to other
+        ;; equal-weight recommendations to avoid rewinding livelock scenarios
+        ((and (eql ':augment x-rec)
+              (not (zerop x-weight))
+              (eql x-weight y-weight))
+         x)
         ;; if we're both (`HOLD' 0)ing, aggregate the root-bucket of each pong
         ((and (eql ':hold x-rec) (eql ':hold y-rec)
               (zerop x-weight) (zerop y-weight))

--- a/src/operations/scan.lisp
+++ b/src/operations/scan.lisp
@@ -130,9 +130,9 @@ When INTERNAL-ROOT-SET is supplied, discard HOLD recommendations which emanate f
         ((and (eql ':hold y-rec)
               (member y-root internal-root-set :test #'address=))
          x)
-        ;; if we're both `HOLD'ing with the same weight, then aggregate
-        ;; the root-bucket of each pong
-        ((and (eql ':hold x-rec) (eql ':hold y-rec) (= x-weight y-weight))
+        ;; if we're both (`HOLD' 0)ing, aggregate the root-bucket of each pong
+        ((and (eql ':hold x-rec) (eql ':hold y-rec)
+              (zerop x-weight) (zerop y-weight))
          (initialize-and-return ((pong (copy-message-pong x)))
            (setf (message-pong-root-bucket pong)
                  (remove-duplicates (union (message-pong-root-bucket x)

--- a/src/operations/scan.lisp
+++ b/src/operations/scan.lisp
@@ -138,16 +138,6 @@ When INTERNAL-ROOT-SET is supplied, discard HOLD recommendations which emanate f
                  (remove-duplicates (union (message-pong-root-bucket x)
                                            (message-pong-root-bucket y))
                                     :test #'address=))))
-        ;; prefer non-zero `HOLD's (which become `REWEIGHT's) to other
-        ;; equal-weight recommendations to avoid rewinding-related problems
-        ((and (eql ':hold x-rec)
-              (not (zerop x-weight))
-              (eql x-weight y-weight))
-         x)
-        ((and (eql ':hold y-rec)
-              (not (zerop y-weight))
-              (eql x-weight y-weight))
-         y)
         ;; (`HOLD' 0) is an expensive operation: either we idle or we have to
         ;; coordinate across multiple trees.  prefer easier actions.
         ((and (eql ':hold x-rec)

--- a/src/supervisor.lisp
+++ b/src/supervisor.lisp
@@ -132,6 +132,7 @@ PONG: The PONG that this process received at its START."
         (loop :for (parent pistil match-edge) :in values-lists
               :do (when (or parent pistil match-edge)
                     (log-entry :entry-type ':check-roots-aborting
+                               :log-level 1
                                :roots roots
                                :values-lists values-lists
                                :parent parent
@@ -186,8 +187,11 @@ PONG: The PONG that this process received at its START."
 (define-process-upkeep ((supervisor supervisor))
     (EVALUATE-CHECK-PONG stale-pong local-pong replica-pong)
   "CHECK-PONG results in a refreshed REPLICA-PONG, which we're to compare against STALE-PONG and LOCAL-PONG, aborting if they differ in a way that indicates stale information."
-  (setf (process-lockable-aborting? supervisor)
-        (not (pong= stale-pong replica-pong))))
+  (let ((pongs-materially-differ? (not (pong= stale-pong replica-pong))))
+    (if pongs-materially-differ?
+        (log-entry :entry-type ':check-pong-aborting
+                   :log-level 1))
+    (setf (process-lockable-aborting? supervisor) pongs-materially-differ?)))
 
 (define-process-upkeep ((supervisor supervisor)) (ENSURE-ABORTING pong)
   "This command is used upon encountering a negatively-weighted edge rec, to cause the algorithm to crash if the recommendation doesn't resolve itself."

--- a/tests/node.lisp
+++ b/tests/node.lisp
@@ -39,6 +39,9 @@
   (let* ((augment-0 (anatevka::make-message-pong
                      :weight 0
                      :recommendation ':augment))
+         (augment-pos (anatevka::make-message-pong
+                       :weight 1
+                       :recommendation ':augment))
          (augment-neg (anatevka::make-message-pong
                        :weight -1
                        :recommendation ':augment))
@@ -48,23 +51,20 @@
          (hold-0 (anatevka::make-message-pong
                   :weight 0
                   :recommendation ':hold))
-         (hold-pos (anatevka::make-message-pong
-                    :weight 1
-                    :recommendation ':hold))
          (graft-0 (anatevka::make-message-pong
                    :weight 0
                    :recommendation ':graft))
          (zero-weighters (list augment-0 graft-0 contract-0)))
-    ;; non-zero HOLDs have higher precedence than equal-weight ops
+    ;; non-zero AUGMENTs have higher precedence than equal-weight ops
     (is (every #'identity
-               (loop :for rec :in (list ':augment :graft ':expand ':contract)
+               (loop :for rec :in (list ':hold :graft ':expand ':contract)
                      :collect (let ((pong (anatevka::make-message-pong
                                            :weight (anatevka::message-pong-weight
-                                                    hold-pos)
+                                                    augment-pos)
                                            :recommendation rec)))
-                                (eql ':hold
+                                (eql ':augment
                                      (anatevka::message-pong-recommendation
-                                      (anatevka::unify-pongs hold-pos pong)))))))
+                                      (anatevka::unify-pongs augment-pos pong)))))))
     ;; HOLD 0 has lower precedence than other zero-weight ops
     (is (every #'identity
                (loop :for pong :in zero-weighters

--- a/tests/operations/multireweight.lisp
+++ b/tests/operations/multireweight.lisp
@@ -1119,6 +1119,165 @@ The point of this is to show that simultaneous reweighting and rewinding during 
                   :children (list (vv-edge L K))))
             (is (tree-equalp original-tree target-tree))))))))
 
+
+(deftest test-supervisor-multireweight-simultaneous-rewind-non-integer ()
+  "Checks the transformation
+ 0    1    0              0    1    0        0.5  0.5  0.5            0.5  0.5  0.5
+ +    -    +              +    -    +         +    -    +              +    -    +
+ A -> B => C              J <= K <- L         A -> B => C              J <= K <- L
+                                        -->
+      D -> E => F    G <= H <- I                   D -> E => F    G <= H <- I
+      +    -    +    +    -    +                   +    -    +    +    -    +
+      0    1    0    0    1    0                  0.5  0.5  0.5  0.5  0.5  0.5
+d(B, D), d(F, G), d(H, J)  = 1
+The point of this is to show that simultaneous reweighting and rewinding during multireweighting will still ensure progress even if the inter-root-set distance is 1 (or smaller) by using non-integer rewinds.
+"
+  (with-with ((with-courier ())
+              (with-simulation (simulation (*local-courier*)))
+              (with-address-dereferencing ()))
+    (let* ((dryad (spawn-process 'dryad :match-address (register)
+                                        :debug? t))
+           (dryad-address (process-public-address dryad)))
+      (blossom-let (original-tree :dryad dryad-address)
+          ((A :id (id 0 1)
+              :children (list (vv-edge A B))
+              :held-by-roots (list D)
+              :paused? T)
+           (B :id (id 1 1)
+              :children (list (vv-edge B C))
+              :internal-weight 1
+              :match-edge (vv-edge B C)
+              :parent (vv-edge B A)
+              :positive? nil)
+           (C :id (id 2 1)
+              :match-edge (vv-edge C B)
+              :parent (vv-edge C B))
+           (D :id (id 1 0)
+              :children (list (vv-edge D E))
+              :held-by-roots (list A))
+           (E :id (id 2 0)
+              :children (list (vv-edge E F))
+              :internal-weight 1
+              :match-edge (vv-edge E F)
+              :parent (vv-edge E D)
+              :positive? nil)
+           (F :id (id 3 0)
+              :match-edge (vv-edge F E)
+              :parent (vv-edge F E))
+           (G :id (id 4 0)
+              :match-edge (vv-edge G H)
+              :parent (vv-edge G H))
+           (H :id (id 5 0)
+              :children (list (vv-edge H G))
+              :internal-weight 1
+              :match-edge (vv-edge H G)
+              :parent (vv-edge H I)
+              :positive? nil)
+           (I :id (id 6 0)
+              :children (list (vv-edge I H))
+              :held-by-roots (list L)
+              :paused? T)
+           (J :id (id 5 1)
+              :match-edge (vv-edge J K)
+              :parent (vv-edge J K))
+           (K :id (id 6 1)
+              :children (list (vv-edge K J))
+              :internal-weight 1
+              :match-edge (vv-edge K J)
+              :parent (vv-edge K L)
+              :positive? nil)
+           (L :id (id 7 1)
+              :children (list (vv-edge L K))
+              :held-by-roots (list I)))
+
+        (let ((supervisor-left (supervisor simulation
+                                           :recommendation ':hold
+                                           :weight 0
+                                           :edges (list (vv-edge B D))
+                                           :source-root (process-public-address A)
+                                           :target-root (process-public-address D)
+                                           :source-id (slot-value B 'anatevka::id)
+                                           :root-bucket (list
+                                                         (process-public-address D))))
+              (supervisor-right (supervisor simulation
+                                            :recommendation ':hold
+                                            :weight 0
+                                            :edges (list (vv-edge I K))
+                                            :source-root (process-public-address I)
+                                            :target-root (process-public-address L)
+                                            :source-id (slot-value I 'anatevka::id)
+                                            :root-bucket (list (process-public-address L)))))
+          (simulate-add-tree simulation original-tree)
+
+          ;; fill the dryad and add it to the simulation
+          (dolist (node original-tree)
+            (let* ((id (slot-value node 'anatevka::id))
+                   (address (process-public-address node))
+                   (sprouted? (not (null (anatevka::blossom-node-match-edge node)))))
+              (setf (gethash address (anatevka::dryad-ids dryad))       id
+                    (gethash address (anatevka::dryad-sprouted? dryad)) sprouted?)))
+          (simulation-add-event simulation (make-event :callback dryad))
+
+          (simulate-until-dead simulation supervisor-left)
+          (simulate-until-dead simulation supervisor-right)
+          (blossom-let (target-tree :dryad dryad-address)
+              ((A :id (id 0 1)
+                  :internal-weight 0.5
+                  :children (list (vv-edge A B)))
+               (B :id (id 1 1)
+                  :internal-weight 0.5
+                  :children (list (vv-edge B C))
+                  :match-edge (vv-edge B C)
+                  :parent (vv-edge B A)
+                  :positive? nil)
+               (C :id (id 2 1)
+                  :internal-weight 0.5
+                  :match-edge (vv-edge C B)
+                  :parent (vv-edge C B))
+               (D :id (id 1 0)
+                  :internal-weight 0.5
+                  :children (list (vv-edge D E)))
+               (E :id (id 2 0)
+                  :internal-weight 0.5
+                  :children (list (vv-edge E F))
+                  :match-edge (vv-edge E F)
+                  :parent (vv-edge E D)
+                  :positive? nil)
+               (F :id (id 3 0)
+                  :internal-weight 0.5
+                  :match-edge (vv-edge F E)
+                  :parent (vv-edge F E))
+               (G :id (id 4 0)
+                  :internal-weight 0.5
+                  :match-edge (vv-edge G H)
+                  :parent (vv-edge G H))
+               (H :id (id 5 0)
+                  :internal-weight 0.5
+                  :children (list (vv-edge H G))
+                  :match-edge (vv-edge H G)
+                  :parent (vv-edge H I)
+                  :positive? nil)
+               (I :id (id 6 0)
+                  :internal-weight 0.5
+                  :children (list (vv-edge I H)))
+               (J :id (id 5 1)
+                  :internal-weight 0.5
+                  :match-edge (vv-edge J K)
+                  :parent (vv-edge J K))
+               (K :id (id 6 1)
+                  :internal-weight 0.5
+                  :children (list (vv-edge K J))
+                  :match-edge (vv-edge K J)
+                  :parent (vv-edge K L)
+                  :positive? nil)
+               (L :id (id 7 1)
+                  :internal-weight 0.5
+                  :children (list (vv-edge L K)))
+               (BOUNDARY :id (id -1 0)
+                         :match-edge (vv-edge B A)
+                         :parent (vv-edge B A)))
+            (is (tree-equalp original-tree target-tree))))))))
+
 ;;;
 ;;; multi-cluster tests (internal-pong rec edge is cluster-external)
 ;;;

--- a/tests/operations/multireweight.lisp
+++ b/tests/operations/multireweight.lisp
@@ -964,15 +964,15 @@ it declines to take action because C has priority.
 (deftest test-supervisor-multireweight-simultaneous-rewind-halfway ()
   "Checks the transformation
 
- 0    2    0              0    2    0        3/2  1/2  3/2            3/2  1/2  3/2
+ 0    2    0              0    2    0         1    1    1              1    1    1
  +    -    +              +    -    +         +    -    +              +    -    +
  A -> B => C              J <= K <- L         A -> B => C              J <= K <- L
                                         -->
       D -> E => F    G <= H <- I                   D -> E => F    G <= H <- I
       +    -    +    +    -    +                   +    -    +    +    -    +
-      0    2    0    0    2    0                  3/2  1/2  3/2  3/2  1/2  3/2
+      0    2    0    0    2    0                   1    1    1    1    1    1
 
-d(B, D), d(H, J) = 2 and d(F, G) = 3
+d(B, D), d(H, J), d(F, G) = 2
 
 The point of this is to show that simultaneous reweighting and rewinding during multireweighting won't cause a negative-weight edge (all roots in the root-set are rewound) and for inter-root-set distances > 1 the algorithm will progress.
 "
@@ -1008,29 +1008,29 @@ The point of this is to show that simultaneous reweighting and rewinding during 
            (F :id (id 6 0)
               :match-edge (vv-edge F E)
               :parent (vv-edge F E))
-           (G :id (id 9 0)
+           (G :id (id 8 0)
               :match-edge (vv-edge G H)
               :parent (vv-edge G H))
-           (H :id (id 11 0)
+           (H :id (id 10 0)
               :children (list (vv-edge H G))
               :internal-weight 2
               :match-edge (vv-edge H G)
               :parent (vv-edge H I)
               :positive? nil)
-           (I :id (id 13 0)
+           (I :id (id 12 0)
               :children (list (vv-edge I H))
               :held-by-roots (list L)
               :paused? T)
-           (J :id (id 11 2)
+           (J :id (id 10 2)
               :match-edge (vv-edge J K)
               :parent (vv-edge J K))
-           (K :id (id 13 2)
+           (K :id (id 12 2)
               :children (list (vv-edge K J))
               :internal-weight 2
               :match-edge (vv-edge K J)
               :parent (vv-edge K L)
               :positive? nil)
-           (L :id (id 15 2)
+           (L :id (id 14 2)
               :children (list (vv-edge L K))
               :held-by-roots (list I)))
 
@@ -1066,56 +1066,56 @@ The point of this is to show that simultaneous reweighting and rewinding during 
           (simulate-until-dead simulation supervisor-right)
           (blossom-let (target-tree :dryad dryad-address)
               ((A :id (id 0 2)
-                  :internal-weight 3/2
+                  :internal-weight 1
                   :children (list (vv-edge A B)))
                (B :id (id 2 2)
                   :children (list (vv-edge B C))
-                  :internal-weight 1/2
+                  :internal-weight 1
                   :match-edge (vv-edge B C)
                   :parent (vv-edge B A)
                   :positive? nil)
                (C :id (id 4 2)
-                  :internal-weight 3/2
+                  :internal-weight 1
                   :match-edge (vv-edge C B)
                   :parent (vv-edge C B))
                (D :id (id 2 0)
-                  :internal-weight 3/2
+                  :internal-weight 1
                   :children (list (vv-edge D E)))
                (E :id (id 4 0)
                   :children (list (vv-edge E F))
-                  :internal-weight 1/2
+                  :internal-weight 1
                   :match-edge (vv-edge E F)
                   :parent (vv-edge E D)
                   :positive? nil)
                (F :id (id 6 0)
-                  :internal-weight 3/2
+                  :internal-weight 1
                   :match-edge (vv-edge F E)
                   :parent (vv-edge F E))
-               (G :id (id 9 0)
-                  :internal-weight 3/2
+               (G :id (id 8 0)
+                  :internal-weight 1
                   :match-edge (vv-edge G H)
                   :parent (vv-edge G H))
-               (H :id (id 11 0)
+               (H :id (id 10 0)
                   :children (list (vv-edge H G))
-                  :internal-weight 1/2
+                  :internal-weight 1
                   :match-edge (vv-edge H G)
                   :parent (vv-edge H I)
                   :positive? nil)
-               (I :id (id 13 0)
-                  :internal-weight 3/2
+               (I :id (id 12 0)
+                  :internal-weight 1
                   :children (list (vv-edge I H)))
-               (J :id (id 11 2)
-                  :internal-weight 3/2
+               (J :id (id 10 2)
+                  :internal-weight 1
                   :match-edge (vv-edge J K)
                   :parent (vv-edge J K))
-               (K :id (id 13 2)
+               (K :id (id 12 2)
                   :children (list (vv-edge K J))
-                  :internal-weight 1/2
+                  :internal-weight 1
                   :match-edge (vv-edge K J)
                   :parent (vv-edge K L)
                   :positive? nil)
-               (L :id (id 15 2)
-                  :internal-weight 3/2
+               (L :id (id 14 2)
+                  :internal-weight 1
                   :children (list (vv-edge L K))))
             (is (tree-equalp original-tree target-tree))))))))
 

--- a/tests/operations/reweight.lisp
+++ b/tests/operations/reweight.lisp
@@ -93,9 +93,9 @@ d(C, D) = 2
 
   A <== B <-- C    D --> E ==> F   -->   A <== B <-- C    D --> E ==> F
   +     -     +    +     -     +         +     -     +    +     -     +
-  0     2     0    0     2     0        3/2   1/2   3/2  3/2   1/2   3/2
+  0     2     0    0     2     0         1     1     1    1     1     1
 
-d(C, D) = 3
+d(C, D) = 2
 
 The point of this test is to show that we can break livelock induced by
 repeated reweighting and rewinding.
@@ -119,16 +119,16 @@ repeated reweighting and rewinding.
            (C :id (id 4 0)
               :children (list (vv-edge C B))
               :paused? T)
-           (D :id (id 7 0)
+           (D :id (id 6 0)
               :children (list (vv-edge D E))
               :paused? T)
-           (E :id (id 9 0)
+           (E :id (id 8 0)
               :internal-weight 2
               :children (list (vv-edge E F))
               :match-edge (vv-edge E F)
               :parent (vv-edge E D)
               :positive? nil)
-           (F :id (id 11 0)
+           (F :id (id 10 0)
               :match-edge (vv-edge F E)
               :parent (vv-edge F E)))
         (let ((supervisor-left (supervisor simulation
@@ -160,29 +160,29 @@ repeated reweighting and rewinding.
           (simulate-until-dead simulation supervisor-right)
           (blossom-let (target-tree :dryad dryad-address)
               ((A :id (id 0 0)
-                  :internal-weight 3/2
+                  :internal-weight 1
                   :match-edge (vv-edge A B)
                   :parent (vv-edge A B))
                (B :id (id 2 0)
                   :children (list (vv-edge B A))
-                  :internal-weight 1/2
+                  :internal-weight 1
                   :parent (vv-edge B C)
                   :match-edge (vv-edge B A)
                   :positive? nil)
                (C :id (id 4 0)
-                  :internal-weight 3/2
+                  :internal-weight 1
                   :children (list (vv-edge C B)))
-               (D :id (id 7 0)
-                  :internal-weight 3/2
+               (D :id (id 6 0)
+                  :internal-weight 1
                   :children (list (vv-edge D E)))
-               (E :id (id 9 0)
-                  :internal-weight 1/2
+               (E :id (id 8 0)
+                  :internal-weight 1
                   :children (list (vv-edge E F))
                   :match-edge (vv-edge E F)
                   :parent (vv-edge E D)
                   :positive? nil)
-               (F :id (id 11 0)
-                  :internal-weight 3/2
+               (F :id (id 10 0)
+                  :internal-weight 1
                   :match-edge (vv-edge F E)
                   :parent (vv-edge F E)))
             (is (tree-equalp original-tree target-tree))))))))


### PR DESCRIPTION
I really thought I did something in #86 but turns out I was wrong.

The situation I observed was not simply due to an unfortunately timed reweight + rewind -- it was only possible due to a very unlucky combination of stale information + simultaneous reweights.

<img width="906" height="548" alt="Screenshot 2025-10-04 at 8 29 35 PM" src="https://github.com/user-attachments/assets/8f16029e-3b48-4705-88b1-1afaac860ec9" />

Revisiting the offending problem graph -- the only reason that 11241 is able to make it to its reweight critical section is that the pong from 11226 that contributed to its reweight was so stale that 11226 was still unweighted and unmatched at the time the pong was sent:

```
30.26: [#<D-N 11241>] processing reply pong AUGMENT 4 #<11241>--->#<11237> from #<11237>
30.26: [#<D-N 11241>] processing reply pong AUGMENT 2 #<11241>--->#<11226> from #<11226>
30.26: [#<D-N 11241>] processing reply pong AUGMENT 4 #<11241>--->#<11274> from #<11274>
30.26: [#<D-N 11241>] processing reply pong AUGMENT 2 #<11241>--->#<8435> from #<8435>
30.26: [#<D-N 11241>] unified pong is AUGMENT 2 #<11241>--->#<8435> from #<8435>
30.34: [#<D-S 36117>] got AUGMENT 2 #<11241>--->#<8435> from #<11241>
```

This stale pong `AUGMENT 2 #<11241>--->#<11226> from #<11226>` then happens to have the same weight as the soft pong that is returned to 11241 during CHECK-REWEIGHT, as 11226 is in the middle of a CONTRACT 2 reweight and has been de-weighted back to 0:

```
44.06: [#<D-N 11241>] pinging vertices #<14111> #<11237> #<11226> #<11156> #<11274> #<8435>
46.94: [#<D-N 11241>] processing reply pong AUGMENT 2 #<11241>--->#<14111> from #<14111>
46.94: [#<D-N 11241>] processing reply pong AUGMENT 2 #<11241>--->#<11237> from #<14111>
46.94: [#<D-N 11241>] processing reply pong HOLD 2 #<11241>--->#<11226> from #<14111>
46.94: [#<D-N 11241>] processing reply pong AUGMENT 4 #<11241>--->#<11156> from #<11156>
46.94: [#<D-N 11241>] processing reply pong AUGMENT 2 #<11241>--->#<11274> from #<11274>
46.94: [#<D-N 11241>] processing reply pong AUGMENT 2 #<11241>--->#<8435> from #<8435>
46.94: [#<D-N 11241>] unified pong is AUGMENT 2 #<11241>--->#<8435> from #<8435>
```

As such, we get a `HOLD 2 #<11241>--->#<11226> from #<14111>` pong and think everything is fine because the lowest-weight rec is still 2, so we clear ourselves to reweight. And then, 11241 is a solo node (whereas 11226 is part of a 3-tree), it is able to reweight, re-check (deciding that everything is once again fine), and finalize the reweight before 11226's tree realizes it has reweighted too much and needs to rewind, resulting in a negative-weight edge between 11241 and 11226.

Clearly this is very rare, but of course that has never stopped me, so after much consternation and deep thought I realized that we basically just need a way to say "don't trust mid-reweight pongs from negative nodes." However, making them non-pingable is a recipe for deadlock, and so what I came up with is having the negative nodes "pretend" that they actually havent reweighted until the operation is fully finalized. We do this by "stashing" their original weights in a slot before the reweight happens and returning this value when pinged. This value is then "unstashed" at the end of the reweight operation.