### PR TITLE
Clear `HELD-BY-ROOTS` slot of lock targets for all successful operations

### DIFF
--- a/src/operations/augment.lisp
+++ b/src/operations/augment.lisp
@@ -56,6 +56,7 @@
                             `(CHECK-PONG ,pong)
                             `(AUGMENT ,edge)
                             `(AUGMENT ,(reverse-blossom-edge edge))
+                            `(CLEAR-HELD-BY-ROOTS ,targets)
                             `(BROADCAST-UNLOCK :destroy? ,T)
                             `(HALT)))))
 

--- a/src/operations/contract.lisp
+++ b/src/operations/contract.lisp
@@ -90,6 +90,7 @@ PETAL-CHILD-EDGES: The list of child edges attached to the blossoms in the subtr
                             `(CHECK-PONG ,pong)
                             `(BROADCAST-PINGABILITY ,targets :NONE)
                             `(START-INNER-CONTRACT)
+                            `(CLEAR-HELD-BY-ROOTS ,targets)
                             `(BROADCAST-UNLOCK)
                             `(HALT)))))
 

--- a/src/operations/expand.lisp
+++ b/src/operations/expand.lisp
@@ -57,6 +57,7 @@
                             `(CHECK-ROOTS ,targets)
                             `(CHECK-INNER-BLOSSOM ,blossom ,source-root)
                             `(EXPAND-INNER-BLOSSOM ,blossom)
+                            `(CLEAR-HELD-BY-ROOTS ,targets)
                             `(BROADCAST-UNLOCK)
                             `(HALT)))))
 

--- a/src/operations/graft.lisp
+++ b/src/operations/graft.lisp
@@ -54,6 +54,7 @@
                             `(BROADCAST-PINGABILITY ,targets :SOFT)
                             `(CHECK-PONG ,pong)
                             `(INNER-GRAFT ,pong)
+                            `(CLEAR-HELD-BY-ROOTS ,targets)
                             `(BROADCAST-UNLOCK)))))
 
 (define-process-upkeep ((supervisor supervisor)) (INNER-GRAFT pong)

--- a/src/operations/reweight.lisp
+++ b/src/operations/reweight.lisp
@@ -137,6 +137,7 @@
                             `(BROADCAST-PINGABILITY ,targets :SOFT)
                             `(CHECK-REWINDING (,source-root) ,pong 0)
                             `(BROADCAST-UNSTASH-WEIGHT ,targets)
+                            `(CLEAR-HELD-BY-ROOTS ,targets)
                             `(BROADCAST-UNLOCK)
                             `(HALT)))))
 

--- a/src/supervisor.lisp
+++ b/src/supervisor.lisp
@@ -208,3 +208,11 @@ PONG: The PONG that this process received at its START."
              (make-message-broadcast-pingability :ping-type new-type)))
       (with-replies (replies) (send-message-batch #'payload-constructor targets)
         nil))))
+
+(define-process-upkeep ((supervisor supervisor)) (CLEAR-HELD-BY-ROOTS roots)
+  "If the operation was successful (essentially, if the supervisor is not ABORTING?), unset `HELD-BY-ROOTS' for everyone in `ROOTS' (equal to the lock targets)."
+  (unless (process-lockable-aborting? supervisor)
+    (flet ((payload-constructor ()
+             (make-message-set :slots '(held-by-roots) :values `(,nil))))
+      (with-replies (replies :returned? returned?)
+                    (send-message-batch #'payload-constructor roots)))))

--- a/tests/operations/multireweight.lisp
+++ b/tests/operations/multireweight.lisp
@@ -1394,8 +1394,7 @@ d(B, D), d(J, L) = 2 and d(F, G) = 1
           (simulate-until-dead simulation supervisor-right)
           (blossom-let (target-tree :dryad dryad-address)
               ((A :id (id 0 2)
-                  :children (list (vv-edge A B))
-                  :held-by-roots (list D))
+                  :children (list (vv-edge A B)))
                (B :id (id 2 2)
                   :children (list (vv-edge B C))
                   :internal-weight 2
@@ -1406,8 +1405,7 @@ d(B, D), d(J, L) = 2 and d(F, G) = 1
                   :match-edge (vv-edge C B)
                   :parent (vv-edge C B))
                (D :id (id 2 0)
-                  :children (list (vv-edge D E))
-                  :held-by-roots (list A))
+                  :children (list (vv-edge D E)))
                (E :id (id 4 0)
                   :children (list (vv-edge E F))
                   :internal-weight 2
@@ -1632,8 +1630,7 @@ d(B, D), d(H, J), d(N, P) = 2 and d(F, G), d(L, M) = 1
                   :positive? nil)
                (I :id (id 11 0)
                   :internal-weight 0
-                  :children (list (vv-edge I H))
-                  :held-by-roots (list L))
+                  :children (list (vv-edge I H)))
                (J :id (id 9 2)
                   :internal-weight 0
                   :match-edge (vv-edge J K)
@@ -1646,8 +1643,7 @@ d(B, D), d(H, J), d(N, P) = 2 and d(F, G), d(L, M) = 1
                   :positive? nil)
                (L :id (id 13 2)
                   :internal-weight 0
-                  :children (list (vv-edge L K))
-                  :held-by-roots (list I))
+                  :children (list (vv-edge L K)))
                (M :id (id 14 2)
                   :internal-weight 1
                   :children (list (vv-edge M N)))
@@ -1886,8 +1882,7 @@ d(B, D), d(H, J), d(N, P), d(U, W) = 2 and d(F, G), d(R, S) = 1 and d(L, M) = 2
                   :positive? nil)
                (I :id (id 11 0)
                   :internal-weight 0
-                  :children (list (vv-edge I H))
-                  :held-by-roots (list L))
+                  :children (list (vv-edge I H)))
                (J :id (id 9 2)
                   :internal-weight 0
                   :match-edge (vv-edge J K)
@@ -1900,8 +1895,7 @@ d(B, D), d(H, J), d(N, P), d(U, W) = 2 and d(F, G), d(R, S) = 1 and d(L, M) = 2
                   :positive? nil)
                (L :id (id 13 2)
                   :internal-weight 0
-                  :children (list (vv-edge L K))
-                  :held-by-roots (list I))
+                  :children (list (vv-edge L K)))
                (M :id (id 15 2)
                   :internal-weight 1
                   :children (list (vv-edge M N)))
@@ -1940,8 +1934,7 @@ d(B, D), d(H, J), d(N, P), d(U, W) = 2 and d(F, G), d(R, S) = 1 and d(L, M) = 2
                   :positive? nil)
                (V :id (id 26 0)
                   :internal-weight 0
-                  :children (list (vv-edge V U))
-                  :held-by-roots (list Y))
+                  :children (list (vv-edge V U)))
                (W :id (id 24 2)
                   :internal-weight 0
                   :match-edge (vv-edge W X)
@@ -1954,6 +1947,5 @@ d(B, D), d(H, J), d(N, P), d(U, W) = 2 and d(F, G), d(R, S) = 1 and d(L, M) = 2
                   :positive? nil)
                (Y :id (id 28 2)
                   :internal-weight 0
-                  :children (list (vv-edge Y X))
-                  :held-by-roots (list V)))
+                  :children (list (vv-edge Y X))))
             (is (tree-equalp original-tree target-tree))))))))


### PR DESCRIPTION
In https://github.com/dtqec/anatevka/pull/80 we didn't go far enough -- the `held-by-roots` slot should be unset at the end of _every_ successful operation -- not just multireweight operations. Otherwise stale information in this slot can lead to a strange situation where we lock superfluous targets.

In the worst case, this can actually result in _**livelock**_! 🚨

For example, in the situation below, we get stuck on a `GRAFT 1 #<93356>--->#<90201> [#<372123>: #<93352>-]-->#<93356> from #<372123>` that keeps failing.

This happens because the `target-root` `#<93356>` still has its `held-by-roots` slot set to `(#<96678>)` from an earlier failed `HOLD` operation. `#<93356>` eventually moves on and is pulled into an `AUGMENT`, but the slot remains set. `#<96678>` ends up being contracted in several layers of macrovertices, the topmost being `#<372123>`. Then `#<372123>` tries to `GRAFT 1` with `#<93356>` as the `target-root` and the lock targets ultimately contain both `#<372123>` (a macrovertex) and `#<96678>` (a vertex contained in macrovertex `#<372123>`) and the lock process fails.

If we always unset `held-by-roots` of all lock targets when a supervisor operation is successful, this cannot happen.

```
241.6: [#<D-S 257393>] got HOLD 0 #<96699>--->#<96598> from #<93356> w/ root-bucket (#<96678>)
242.2: [#<D-S 257393>] closing with failure

268.3: [#<D-S 268892>] got AUGMENT 0 #<90201>--->#<93356> from #<83940>
276.1: [#<D-S 268892>] closing with success

500.4: [#<D-S 333791>] got CONTRACT 0 #<96699>--->#<96678> from #<96662>
507.3: [#<D-N 335214>] completed setting up (peduncle: #<96598>--->#<96678>; match: [#<335214>: #<96678>-]-->#<96598>; children: ; parent: [#<335214>: #<96678>-]-->#<96598>; petals: #<96678>--->#<93352> #<93352>--->#<96699> #<96699>--->#<96678>; pistil: NIL)
508.3: [#<D-S 333791>] closing with success

549.4: [#<D-S 345061>] got CONTRACT 0 [#<335214>: #<93352>-]-->#<93333> from #<96662>
552.6: [#<D-N 345528>] completed setting up (peduncle: NIL; match: NIL; children: [#<345528>: #<93321>-]-->#<93251> [#<345528>: #<96662>-]-->#<96703>; parent: NIL; petals: #<96662>--->#<93331> #<93331>--->#<93321> #<93321>--->#<93245> #<93245>--->#<93327> #<93327>--->#<96598> #<96598>--[->#<96678> :#<335214>] [#<335214>: #<93352>-]-->#<93333> #<93333>--->#<93296> #<93296>--->#<96713> #<96713>--->#<96601> #<96601>--->#<96662>; pistil: NIL)
553.7: [#<D-S 345061>] closing with success

617.7: [#<D-S 361242>] got CONTRACT 0 #<93339>--->#<93222> from #<345528>
621.5: [#<D-N 362271>] completed setting up (peduncle: NIL; match: NIL; children: [#<362271>: #<93339>-]-->#<93316> [#<362271>: #<93222>-]-->#<90172>; parent: NIL; petals: [#<345528>: #<96662>-]-->#<96703> #<96703>--->#<93339> #<93339>--->#<93222> #<93222>--->#<93251> #<93251>--[->#<93321> :#<345528>]; pistil: NIL)
622.5: [#<D-S 361242>] closing with success

639.4: [#<D-S 367142>] got CONTRACT 0 #<86624>--->#<86667> from #<362271>
642.1: [#<D-N 367885>] completed setting up (peduncle: #<90157>--->#<86667>; match: [#<367885>: #<86667>-]-->#<90157>; children: ; parent: [#<367885>: #<86667>-]-->#<90157>; petals: #<86667>--->#<86661> #<86661>--->#<86624> #<86624>--->#<86667>; pistil: NIL)
643.2: [#<D-S 367142>] closing with success

656.1: [#<D-S 371609>] got CONTRACT 0 [#<367885>: #<86624>-]-[->#<93327> :#<362271>] from #<362271>
658.8: [#<D-N 372123>] completed setting up (peduncle: NIL; match: NIL; children: [#<372123>: #<93339>-]-->#<93316>; parent: NIL; petals: [#<362271>: #<93222>-]-->#<90172> #<90172>--->#<90207> #<90207>--->#<90157> #<90157>--[->#<86667> :#<367885>] [#<367885>: #<86624>-]-[->#<93327> :#<362271>]; pistil: NIL)
659.6: [#<D-S 371609>] closing with success

1001.: [#<D-S 460087>] got GRAFT 1 #<93356>--->#<90201> [#<372123>: #<93352>-]-->#<93356> from #<372123>
1003.: [#<D-S 460087>] closing with failure
1009.: [#<D-S 461542>] got GRAFT 1 #<93356>--->#<90201> [#<372123>: #<93352>-]-->#<93356> from #<372123>
1010.: [#<D-S 461542>] closing with failure
1016.: [#<D-S 462588>] got GRAFT 1 #<93356>--->#<90201> [#<372123>: #<93352>-]-->#<93356> from #<372123>
1018.: [#<D-S 462588>] closing with failure
1024.: [#<D-S 463787>] got GRAFT 1 #<93356>--->#<90201> [#<372123>: #<93352>-]-->#<93356> from #<372123>
1025.: [#<D-S 463787>] closing with failure
1031.: [#<D-S 465238>] got GRAFT 1 #<93356>--->#<90201> [#<372123>: #<93352>-]-->#<93356> from #<372123>
1034.: [#<D-S 465238>] closing with failure
1040.: [#<D-S 466628>] got GRAFT 1 #<93356>--->#<90201> [#<372123>: #<93352>-]-->#<93356> from #<372123>
1041.: [#<D-S 466628>] closing with failure
1047.: [#<D-S 467775>] got GRAFT 1 #<93356>--->#<90201> [#<372123>: #<93352>-]-->#<93356> from #<372123>
1049.: [#<D-S 467775>] closing with failure
```